### PR TITLE
feat(action): support prompt_file input as an alternative to prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ jobs:
           NOTES: ${{ steps.notes.outputs.result }}
 ```
 
+For longer prompts that you want to reuse, commit the prompt text to the repo and pass it with `prompt_file`. The path is resolved relative to `GITHUB_WORKSPACE`, and it is mutually exclusive with `prompt`.
+
+```yaml
+# .github/workflows/triage.yml
+- uses: pullfrog/pullfrog@v0
+  with:
+    prompt_file: .github/pullfrog/triage.md
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+# .github/workflows/weekly-cleanup.yml
+- uses: pullfrog/pullfrog@v0
+  with:
+    prompt_file: .github/pullfrog/triage.md
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
 ### Example: Structured Output with Zod Schema
 
 You can force the agent to return structured JSON output by providing a JSON schema. This allows you to reliably parse and use the agent's response in subsequent workflow steps.

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,10 @@ author: "Pullfrog"
 inputs:
   prompt:
     description: "Prompt to send to the agent (string or JSON payload)"
-    required: true
+    required: false
+  prompt_file:
+    description: "Path to a file (relative to GITHUB_WORKSPACE) whose contents will be used as the prompt. Exactly one of `prompt` or `prompt_file` must be set."
+    required: false
   timeout:
     description: "Maximum run duration (e.g., 10m, 1h30m). Default: 1h"
     required: false

--- a/utils/payload.test.ts
+++ b/utils/payload.test.ts
@@ -1,10 +1,34 @@
-import { Inputs, JsonPayload } from "./payload.ts";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Inputs, JsonPayload, resolvePromptInput } from "./payload.ts";
+
+const savedEnv = { ...process.env };
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "pullfrog-payload-test-"));
+  process.env = { ...savedEnv };
+  delete process.env.INPUT_PROMPT;
+  delete process.env.INPUT_PROMPT_FILE;
+  delete process.env.GITHUB_WORKSPACE;
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  process.env = { ...savedEnv };
+});
 
 describe("Inputs schema", () => {
-  it("only prompt is required", () => {
+  it("accepts prompt inputs", () => {
     const result = Inputs.assert({ prompt: "test prompt" });
     expect(result).toEqual({ prompt: "test prompt" });
-    expect(() => Inputs.assert({})).toThrow();
+    expect(Inputs.assert({ prompt_file: ".github/pullfrog/triage.md" })).toEqual({
+      prompt_file: ".github/pullfrog/triage.md",
+    });
+    expect(() => Inputs.assert({})).not.toThrow();
   });
 
   it.each([
@@ -27,6 +51,75 @@ describe("Inputs schema", () => {
   it.each([["push"], ["shell"]] as const)("should reject invalid %s values", (prop) => {
     const input = { prompt: "test", [prop]: "invalid" as any };
     expect(() => Inputs.assert(input)).toThrow();
+  });
+});
+
+describe("resolvePromptInput", () => {
+  it("returns the prompt input when only prompt is set", () => {
+    process.env.INPUT_PROMPT = "test prompt";
+
+    expect(resolvePromptInput()).toBe("test prompt");
+  });
+
+  it("reads prompt_file relative to GITHUB_WORKSPACE", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    process.env.INPUT_PROMPT_FILE = ".github/pullfrog/triage.md";
+    const promptPath = join(tempDir, ".github", "pullfrog", "triage.md");
+    mkdirSync(dirname(promptPath), { recursive: true });
+    writeFileSync(promptPath, "triage prompt\n");
+
+    expect(resolvePromptInput()).toBe("triage prompt\n");
+  });
+
+  it("throws when prompt and prompt_file are both set", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    process.env.INPUT_PROMPT = "test prompt";
+    process.env.INPUT_PROMPT_FILE = ".github/pullfrog/triage.md";
+
+    expect(() => resolvePromptInput()).toThrow(
+      "Set exactly one of 'prompt' or 'prompt_file' inputs, not both."
+    );
+  });
+
+  it("throws when neither prompt nor prompt_file is set", () => {
+    expect(() => resolvePromptInput()).toThrow(
+      "One of 'prompt' or 'prompt_file' inputs is required."
+    );
+  });
+
+  it("throws when prompt_file resolves outside GITHUB_WORKSPACE", () => {
+    const workspace = join(tempDir, "workspace");
+    mkdirSync(workspace);
+    process.env.GITHUB_WORKSPACE = workspace;
+    process.env.INPUT_PROMPT_FILE = "../triage.md";
+
+    expect(() => resolvePromptInput()).toThrow(
+      'prompt_file "../triage.md" resolves outside GITHUB_WORKSPACE.'
+    );
+  });
+
+  it("allows an absolute prompt_file path inside GITHUB_WORKSPACE", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    const promptPath = join(tempDir, ".github", "pullfrog", "triage.md");
+    mkdirSync(dirname(promptPath), { recursive: true });
+    writeFileSync(promptPath, "absolute prompt\n");
+    process.env.INPUT_PROMPT_FILE = promptPath;
+
+    expect(resolvePromptInput()).toBe("absolute prompt\n");
+  });
+
+  it("does not parse prompt_file contents as an internal JSON payload", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    const promptPath = join(tempDir, "prompt.json");
+    const prompt = JSON.stringify({
+      "~pullfrog": true,
+      version: "0.1.6",
+      prompt: "internal dispatch prompt",
+    });
+    writeFileSync(promptPath, prompt);
+    process.env.INPUT_PROMPT_FILE = promptPath;
+
+    expect(resolvePromptInput()).toBe(prompt);
   });
 });
 

--- a/utils/payload.test.ts
+++ b/utils/payload.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -121,6 +121,79 @@ describe("resolvePromptInput", () => {
 
     expect(resolvePromptInput()).toBe(prompt);
   });
+
+  it("rejects a symlink that resolves outside GITHUB_WORKSPACE", () => {
+    // workspace lives under a sibling directory; the symlink itself is inside
+    // workspace but points to an "outside" target. lexical check passes
+    // (`.github/escape.md` does not traverse out of workspace), so only the
+    // realpath check can catch the bypass.
+    const workspace = join(tempDir, "workspace");
+    const outside = join(tempDir, "outside");
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+    const outsideFile = join(outside, "secret.md");
+    writeFileSync(outsideFile, "secret\n");
+    const symlinkDir = join(workspace, ".github");
+    mkdirSync(symlinkDir, { recursive: true });
+    symlinkSync(outsideFile, join(symlinkDir, "escape.md"));
+
+    process.env.GITHUB_WORKSPACE = workspace;
+    process.env.INPUT_PROMPT_FILE = ".github/escape.md";
+
+    expect(() => resolvePromptInput()).toThrow(
+      'prompt_file ".github/escape.md" resolves outside GITHUB_WORKSPACE.'
+    );
+  });
+
+  it("allows a symlink that resolves inside GITHUB_WORKSPACE", () => {
+    // sanity check the symlink path: a symlink whose realpath stays inside
+    // the workspace should still be readable.
+    const workspace = realpathSync(tempDir);
+    const target = join(workspace, "shared", "triage.md");
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, "shared prompt\n");
+    const linkDir = join(workspace, ".github", "pullfrog");
+    mkdirSync(linkDir, { recursive: true });
+    symlinkSync(target, join(linkDir, "triage.md"));
+
+    process.env.GITHUB_WORKSPACE = workspace;
+    process.env.INPUT_PROMPT_FILE = ".github/pullfrog/triage.md";
+
+    expect(resolvePromptInput()).toBe("shared prompt\n");
+  });
+
+  it("throws when prompt_file is empty", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    const promptPath = join(tempDir, "empty.md");
+    writeFileSync(promptPath, "");
+    process.env.INPUT_PROMPT_FILE = "empty.md";
+
+    expect(() => resolvePromptInput()).toThrow('prompt_file "empty.md" is empty.');
+  });
+
+  it("throws when prompt_file is whitespace-only", () => {
+    process.env.GITHUB_WORKSPACE = tempDir;
+    const promptPath = join(tempDir, "blank.md");
+    writeFileSync(promptPath, "   \n\t\n");
+    process.env.INPUT_PROMPT_FILE = "blank.md";
+
+    expect(() => resolvePromptInput()).toThrow('prompt_file "blank.md" is empty.');
+  });
+
+  it.runIf(process.platform === "win32")(
+    "matches GITHUB_WORKSPACE case-insensitively on Windows",
+    () => {
+      // on Windows the filesystem is case-insensitive but `resolve()` preserves
+      // input case, so without normalization a mixed-case GITHUB_WORKSPACE
+      // would falsely reject paths that genuinely live inside it.
+      process.env.GITHUB_WORKSPACE = tempDir.toUpperCase();
+      const promptPath = join(tempDir, "triage.md");
+      writeFileSync(promptPath, "windows prompt\n");
+      process.env.INPUT_PROMPT_FILE = promptPath;
+
+      expect(resolvePromptInput()).toBe("windows prompt\n");
+    }
+  );
 });
 
 describe("JsonPayload schema", () => {

--- a/utils/payload.ts
+++ b/utils/payload.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { isAbsolute, resolve, sep } from "node:path";
 import * as core from "@actions/core";
 import { type } from "arktype";
@@ -107,6 +107,19 @@ export function resolvePromptInput(): ResolvedPromptInput {
   return jsonPayload;
 }
 
+// matches runCli.ts:normalizePathForCompare — windows filesystems are
+// case-insensitive but `resolve()` preserves input case, so we lowercase both
+// sides before comparing.
+function normalizePathForCompare(path: string): string {
+  return process.platform === "win32" ? path.toLowerCase() : path;
+}
+
+function isOutsideWorkspace(candidate: string, workspace: string): boolean {
+  const c = normalizePathForCompare(candidate);
+  const w = normalizePathForCompare(workspace);
+  return c !== w && !c.startsWith(w + sep);
+}
+
 function resolvePromptFile(input: string): string {
   const workspace = process.env.GITHUB_WORKSPACE;
   if (!workspace) {
@@ -115,12 +128,22 @@ function resolvePromptFile(input: string): string {
 
   const resolvedWorkspace = resolve(workspace);
   const candidate = isAbsolute(input) ? resolve(input) : resolve(resolvedWorkspace, input);
-  if (candidate !== resolvedWorkspace && !candidate.startsWith(resolvedWorkspace + sep)) {
+
+  // lexical boundary check — fires before any filesystem call so a path like
+  // "../triage.md" produces a clean "resolves outside" error instead of ENOENT.
+  if (isOutsideWorkspace(candidate, resolvedWorkspace)) {
     throw new Error(`prompt_file ${JSON.stringify(input)} resolves outside GITHUB_WORKSPACE.`);
   }
 
+  // expand symlinks and re-check. without this, a symlink committed inside the
+  // workspace pointing to e.g. /etc/passwd would pass the lexical check and
+  // get read by readFileSync. realpath both sides so macOS /var → /private/var
+  // (and similar canonicalization) does not produce a false positive.
+  let realCandidate: string;
+  let realWorkspace: string;
   try {
-    return readFileSync(candidate, "utf-8");
+    realCandidate = realpathSync(candidate);
+    realWorkspace = realpathSync(resolvedWorkspace);
   } catch (error) {
     throw new Error(
       `Failed to read prompt_file ${JSON.stringify(input)}: ${
@@ -128,6 +151,26 @@ function resolvePromptFile(input: string): string {
       }`
     );
   }
+
+  if (isOutsideWorkspace(realCandidate, realWorkspace)) {
+    throw new Error(`prompt_file ${JSON.stringify(input)} resolves outside GITHUB_WORKSPACE.`);
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(realCandidate, "utf-8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read prompt_file ${JSON.stringify(input)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+
+  if (!content.trim()) {
+    throw new Error(`prompt_file ${JSON.stringify(input)} is empty.`);
+  }
+  return content;
 }
 
 function resolveNonPromptInputs() {

--- a/utils/payload.ts
+++ b/utils/payload.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { isAbsolute, resolve, sep } from "node:path";
 import * as core from "@actions/core";
 import { type } from "arktype";
 import type { AuthorPermission, PayloadEvent } from "../external.ts";
@@ -46,7 +47,8 @@ function isCollaborator(event: PayloadEvent): boolean {
 // the property being absent. arktype's "prop?" means "optional to include" but
 // if included, must match the type - so we need to explicitly allow undefined.
 export const Inputs = type({
-  prompt: "string",
+  "prompt?": type.string.or("undefined"),
+  "prompt_file?": type.string.or("undefined"),
   "model?": type.string.or("undefined"),
   "timeout?": type.string.or("undefined"),
   "push?": PushPermissionInput.or("undefined"),
@@ -71,19 +73,32 @@ function resolveCwd(cwd: string | undefined): string | undefined {
 export type ResolvedPromptInput = string | typeof JsonPayload.infer;
 
 export function resolvePromptInput(): ResolvedPromptInput {
-  const prompt = core.getInput("prompt", { required: true });
+  const promptInput = core.getInput("prompt");
+  const promptFile = core.getInput("prompt_file");
+
+  if (promptInput && promptFile) {
+    throw new Error("Set exactly one of 'prompt' or 'prompt_file' inputs, not both.");
+  }
+
+  if (promptFile) {
+    return resolvePromptFile(promptFile);
+  }
+
+  if (!promptInput) {
+    throw new Error("One of 'prompt' or 'prompt_file' inputs is required.");
+  }
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(prompt);
+    parsed = JSON.parse(promptInput);
   } catch {
     // JSON parse error is fine (plain text prompt)
-    return prompt;
+    return promptInput;
   }
 
   if (!parsed || typeof parsed !== "object" || !("~pullfrog" in parsed)) {
     // if it doesn't look like a pullfrog payload, return the plain text prompt
-    return prompt;
+    return promptInput;
   }
 
   // validation errors should propagate
@@ -92,8 +107,31 @@ export function resolvePromptInput(): ResolvedPromptInput {
   return jsonPayload;
 }
 
+function resolvePromptFile(input: string): string {
+  const workspace = process.env.GITHUB_WORKSPACE;
+  if (!workspace) {
+    throw new Error("prompt_file is set but GITHUB_WORKSPACE is not defined.");
+  }
+
+  const resolvedWorkspace = resolve(workspace);
+  const candidate = isAbsolute(input) ? resolve(input) : resolve(resolvedWorkspace, input);
+  if (candidate !== resolvedWorkspace && !candidate.startsWith(resolvedWorkspace + sep)) {
+    throw new Error(`prompt_file ${JSON.stringify(input)} resolves outside GITHUB_WORKSPACE.`);
+  }
+
+  try {
+    return readFileSync(candidate, "utf-8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read prompt_file ${JSON.stringify(input)}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
 function resolveNonPromptInputs() {
-  return Inputs.omit("prompt").assert({
+  return Inputs.omit("prompt", "prompt_file").assert({
     model: core.getInput("model") || undefined,
     timeout: core.getInput("timeout") || undefined,
     cwd: core.getInput("cwd") || undefined,


### PR DESCRIPTION
## Summary

- Optional `prompt_file` input on `action.yml`, mutually exclusive with `prompt` (existing callers unaffected; default behavior preserved).
- `resolvePromptInput()` in `utils/payload.ts` now reads from either input; throws if both are set or if neither is set.
- `resolvePromptFile()` resolves paths relative to `GITHUB_WORKSPACE` and rejects anything that resolves outside it, matching the defensive path style in `runCli.ts:isUntrustedPathEntry`.
- Arktype `Inputs` schema extended; `prompt` becomes optional (strictly looser, no schema-visible break).
- `utils/payload.test.ts`: 7 new cases covering only-`prompt`, only-`prompt_file`, both-set, neither-set, outside-workspace, absolute-path-inside-workspace, and JSON-payload pass-through.
- README "Standalone Usage" gets a brief `prompt_file` example.

## Motivation

Two recurring pains with the current `prompt: string` input:

1. **YAML escaping.** Multi-line prompts with backticks, colons, and indentation-significant code blocks need triple-escaping or `|` literal blocks that interact awkwardly with `${{ toJSON(github.event) }}`.
2. **Re-use.** The same prompt body (triage policy, release-notes template) often gets used across multiple workflows; today it has to be inlined into each one.

`prompt_file` lets callers keep prompts at e.g. `.github/pullfrog/triage.md`, version them, comment on them, and reference them from one or more workflows. Mirrors the `body` / `body-file` pattern in `actions/github-script` and `peter-evans/create-pull-request`.

## Validation

- `pnpm typecheck` passes
- `pnpm test` passes 503/503 application tests, including all 7 new payload tests:
  - `resolvePromptInput > returns the prompt input when only prompt is set`
  - `resolvePromptInput > reads prompt_file relative to GITHUB_WORKSPACE`
  - `resolvePromptInput > throws when prompt and prompt_file are both set`
  - `resolvePromptInput > throws when neither prompt nor prompt_file is set`
  - `resolvePromptInput > throws when prompt_file resolves outside GITHUB_WORKSPACE`
  - `resolvePromptInput > allows an absolute prompt_file path inside GITHUB_WORKSPACE`
  - `resolvePromptInput > does not parse prompt_file contents as an internal JSON payload`
- `test/ci.test.ts` fails identically on `main` with `ENOENT: ... /.osc/workspaces/.github/workflows/test.yml` (path-resolution flakiness when the repo is cloned standalone rather than inside a parent test harness). Unrelated to this diff.

AI was used for assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds filesystem-based prompt loading and changes prompt input validation, which could affect workflow behavior and introduces new path-handling/security edge cases (mitigated by workspace boundary + symlink checks and expanded tests).
> 
> **Overview**
> Adds a new `prompt_file` action input as an alternative to `prompt`, letting workflows load prompt text from a repo file for reuse and easier authoring.
> 
> Updates `resolvePromptInput()` to enforce *exactly one* of `prompt`/`prompt_file`, read and validate `prompt_file` relative to `GITHUB_WORKSPACE` (including symlink/realpath and Windows case-handling), and error on empty files; expands unit tests to cover these cases and documents usage in the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50304c2cde95f3e3442df1061f7f576bd645860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->