### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Pullfrog
+
+Thanks for your interest in contributing!
+
+## Prerequisites
+
+- Node.js (see `.node-version` for the exact version)
+- [pnpm](https://pnpm.io/) - `npm install -g pnpm`
+
+## Setup
+
+```bash
+git clone https://github.com/<your-username>/pullfrog.git
+cd pullfrog
+pnpm install
+```
+
+## Running tests
+
+```bash
+pnpm test
+pnpm typecheck
+```
+
+All tests should pass before opening a PR.
+
+## Commit conventions
+
+Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, `test:`.
+
+Example: `feat(action): add prompt_file input`
+
+## Opening a PR
+
+1. Fork the repo
+2. Create a branch: `git checkout -b feat/your-feature`
+3. Make your changes
+4. Run `pnpm typecheck && pnpm test`
+5. Push and open a PR against `main`
+
+## Questions?
+
+Open an issue or reach out at [team@pullfrog.com](mailto:team@pullfrog.com).


### PR DESCRIPTION
The repo doesn't have a CONTRIBUTING.md yet. This adds a minimal guide covering prerequisites, setup, test commands, and commit conventions to help new contributors get started quickly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that doesn’t affect runtime code or shipped artifacts.
> 
> **Overview**
> Adds a new `CONTRIBUTING.md` with basic contributor guidance (prerequisites, local setup, test/typecheck commands, Conventional Commits, and PR workflow) to standardize and speed up onboarding for new contributors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c2f72427754c57ad37f25a60a0738c4f6c5a1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->