### PR TITLE
Fix README schema typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ jobs:
 
 You can force the agent to return structured JSON output by providing a JSON schema. This allows you to reliably parse and use the agent's response in subsequent workflow steps.
 
-You can define your JSON schema directly or uou can use any validation library that converts to JSON Schema. Here's an example using [Zod](https://zod.dev):
+You can define your JSON schema directly or you can use any validation library that converts to JSON Schema. Here's an example using [Zod](https://zod.dev):
 
 ```yaml
 name: Release Check


### PR DESCRIPTION
README currently says `uou` in the structured output example, which makes the public docs sentence read as a typo. This PR corrects that word to `you`.

## What changed

- Fixes `uou` to `you` in the README's structured output section.

## Manual QA

- Open the README's "Example: Structured Output with Zod Schema" section and confirm the sentence reads: "You can define your JSON schema directly or you can use any validation library..."

<details>
<summary><strong>For reviewing agents</strong></summary>

This is a one-word docs-only typo fix, so the trust chain is the diff scope: the README sentence changes while code and generated files remain untouched.

- Is the diff limited to the intended README typo?
- Does the corrected sentence still read naturally in context?

No runtime behavior changes are expected here; spend review time on accidental scope expansion rather than application logic.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-word documentation fix with no runtime or behavioral impact.
> 
> **Overview**
> Corrects a single-word typo in the **Example: Structured Output with Zod Schema** section: `uou` → `you` in the sentence about defining JSON schema directly or using a validation library.
> 
> No code, workflows, or generated files are changed—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7dc585604bec8fa1d2f873fa282a46ddbc68c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->