### PR TITLE
test: replace brittle entryPost import snapshot with transitive-graph invariant

### DIFF
--- a/entryPost.stdlibOnly.test.ts
+++ b/entryPost.stdlibOnly.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 // The GHA `post:` hook runs `node action/entryPost.ts` directly against the
@@ -79,18 +79,16 @@ describe("entryPost.ts stdlib-only invariant (#834)", () => {
     expect(result.violations, JSON.stringify(result.violations, null, 2)).toEqual([]);
   });
 
-  it("walks the full transitive graph (entryPost + 3 utils)", () => {
+  it("walks the full transitive graph (entryPost + all util imports)", () => {
     const result = walk(ENTRY_FILE);
-    expect(result.visited.size).toBeGreaterThanOrEqual(4);
-  });
-
-  it("matches the modules entryPost actually imports today", () => {
-    const direct = extractImports(ENTRY_FILE).sort();
-    expect(direct).toEqual([
-      "./utils/codexRefreshDetect.ts",
-      "./utils/ghaCore.ts",
-      "./utils/postApiFetch.ts",
-      "node:fs",
+    const visited = [...result.visited]
+      .map((f) => relative(import.meta.dirname, f).replaceAll("\\", "/"))
+      .sort();
+    expect(visited).toEqual([
+      "entryPost.ts",
+      "utils/codexRefreshDetect.ts",
+      "utils/ghaCore.ts",
+      "utils/postApiFetch.ts",
     ]);
   });
 });

--- a/entryPost.stdlibOnly.test.ts
+++ b/entryPost.stdlibOnly.test.ts
@@ -91,4 +91,14 @@ describe("entryPost.ts stdlib-only invariant (#834)", () => {
       "utils/postApiFetch.ts",
     ]);
   });
+
+  it("locks down the direct-import surface of entryPost.ts (including stdlib)", () => {
+    const direct = extractImports(ENTRY_FILE).sort();
+    expect(direct).toEqual([
+      "./utils/codexRefreshDetect.ts",
+      "./utils/ghaCore.ts",
+      "./utils/postApiFetch.ts",
+      "node:fs",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Strengthens the `#834` stdlib-only guard for `entryPost.ts` by replacing a loose visited-count check with an exact snapshot of the full transitive import graph, and restores the direct-import surface assertion that was accidentally dropped.

## Changes

**Replaces** `visited.size >= 4` with an exact `toEqual` over every file reached by the static import walk — mapped to repo-relative paths and normalised for cross-platform separators. Any change to the module graph now requires a deliberate snapshot update.

**Restores** the direct-import surface assertion on `entryPost.ts` itself. The transitive visited-set snapshot cannot see `node:` specifiers — `walk()` classifies them as allowed and skips them before queuing — so adding or removing a stdlib import (e.g. `node:child_process`) was invisible to all three tests. The restored third test locks down the exact specifier list including `node:fs`.

## Test plan

- [ ] `pnpm test entryPost.stdlibOnly` passes
- [ ] Temporarily add `import { execSync } from "node:child_process"` to `entryPost.ts` — third test should fail
- [ ] Temporarily add a new relative util import to `entryPost.ts` — second test should fail
- [ ] Temporarily add `import { something } from "@actions/core"` — first test (violations) should fail

## Note

Low risk — test-only change. No runtime or GHA post-hook behaviour is modified.

Closes #58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to `entryPost.stdlibOnly.test.ts`; no runtime or GHA post-hook behavior is modified.
> 
> **Overview**
> **Tightens the `#834` guard** so accidental changes to `entryPost.ts`’s import surface are caught explicitly instead of only via a loose “at least four files visited” check.
> 
> The transitive import walk now **asserts an exact sorted snapshot** of every reachable `.ts` file (`entryPost.ts` plus `utils/codexRefreshDetect.ts`, `ghaCore.ts`, `postApiFetch.ts`), with paths normalized for cross-platform separators. A **restored/renamed third case** pins `entryPost.ts`’s direct specifiers, including `node:fs`, because the walker allows `node:` imports without enqueueing them—so stdlib-only edits were previously easy to miss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5995fefa638b9100dedf36068fedf14a4e55f866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->