### PR TITLE
feat(action): allow disabling progress comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ jobs:
 
 You can also use `pullfrog/pullfrog` as a step in your own workflows. The action exposes a `result` output that can be consumed by subsequent steps.
 
+To hide temporary progress comments in review workflows, set `progress_comments: disabled`. Pullfrog removes the initial “Leaping into action...” comment and skips todo updates; final reviews, result comments, and failure reports are unaffected.
+
 ### Example: Auto-generate release notes on new tags
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   status_checks:
     description: "Post `pullfrog` (run completion) and `pullfrog-approval` (review verdict) commit-status checks on PR runs so they can be required by branch protection: disabled (default) or enabled."
     required: false
+  progress_comments:
+    description: "Post temporary progress comments (`Leaping into action...` and todo updates): enabled (default) or disabled. Final reviews, result comments, and failure reports are unaffected."
+    required: false
   output_schema:
     description: "JSON Schema (draft-07) for structured output validation. When provided, the action output becomes required and must conform to this schema."
     required: false

--- a/agents/postRun.test.ts
+++ b/agents/postRun.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ToolState } from "../toolState.ts";
-import { getUnsubmittedReview } from "./postRun.ts";
+import type { AgentRunContext } from "./shared.ts";
+import { collectPostRunIssues, getUnsubmittedReview } from "./postRun.ts";
 
 function makeToolState(overrides: Partial<ToolState> = {}): ToolState {
   return {
@@ -57,10 +58,57 @@ describe("getUnsubmittedReview", () => {
     ).toBeNull();
   });
 
+  it("still requires a review in comment-free review runs", () => {
+    expect(
+      getUnsubmittedReview(
+        makeToolState({ selectedMode: "Review", hadProgressComment: false }),
+        true
+      )
+    ).toBe("Review");
+  });
+
   it("returns the selected mode when the gate should fire", () => {
     expect(getUnsubmittedReview(makeToolState({ selectedMode: "Review" }))).toBe("Review");
     expect(getUnsubmittedReview(makeToolState({ selectedMode: "IncrementalReview" }))).toBe(
       "IncrementalReview"
     );
+  });
+});
+
+describe("collectPostRunIssues", () => {
+  it("does not require output from silent comment-free review runs", async () => {
+    const ctx = {
+      payload: { progressComments: false, event: { is_pr: true, silent: true } },
+      toolState: makeToolState({
+        selectedMode: "IncrementalReview",
+        hadProgressComment: false,
+      }),
+    } as unknown as AgentRunContext;
+
+    const issues = await collectPostRunIssues(ctx);
+
+    expect(issues.unsubmittedReview).toBeUndefined();
+  });
+
+  it("requires output from non-silent comment-free review runs without is_pr", async () => {
+    const ctx = {
+      payload: { progressComments: false, event: { issue_number: 42 } },
+      toolState: makeToolState({ selectedMode: "Review", hadProgressComment: false }),
+    } as unknown as AgentRunContext;
+
+    const issues = await collectPostRunIssues(ctx);
+
+    expect(issues.unsubmittedReview).toBe("Review");
+  });
+
+  it("does not require review output from plain-prompt runs without a target", async () => {
+    const ctx = {
+      payload: { progressComments: false, event: { trigger: "unknown" } },
+      toolState: makeToolState({ selectedMode: "Review", hadProgressComment: false }),
+    } as unknown as AgentRunContext;
+
+    const issues = await collectPostRunIssues(ctx);
+
+    expect(issues.unsubmittedReview).toBeUndefined();
   });
 });

--- a/agents/postRun.ts
+++ b/agents/postRun.ts
@@ -28,8 +28,10 @@ import {
  * should fire, `null` otherwise — pure read, no side effects, safe to invoke
  * after every agent attempt.
  *
- * the gate is anchored to `hadProgressComment` so silent runs (non-issue
+ * the gate normally follows `hadProgressComment` so silent runs (non-issue
  * events, dispatcher skipped seeding) don't fire a nudge there's no UI for.
+ * `expectsReviewOutput` lets comment-free PR review runs retain the same final
+ * review requirement without storing derived configuration in ToolState.
  *
  * `Review` and `IncrementalReview` have different valid exits:
  *   - Review: only `create_pull_request_review` counts. `report_progress` is
@@ -42,9 +44,12 @@ import {
  * `task`-dispatched `reviewfrog` lens) calls `report_progress` and silences
  * the gate even though the orchestrator never submitted a review.
  */
-export function getUnsubmittedReview(toolState: ToolState): "Review" | "IncrementalReview" | null {
+export function getUnsubmittedReview(
+  toolState: ToolState,
+  expectsReviewOutput = toolState.hadProgressComment
+): "Review" | "IncrementalReview" | null {
   const mode = toolState.selectedMode;
-  if (!toolState.hadProgressComment) return null;
+  if (!expectsReviewOutput) return null;
   if (mode === "Review") return toolState.review ? null : "Review";
   if (mode === "IncrementalReview") {
     return toolState.review || toolState.finalSummaryWritten ? null : "IncrementalReview";
@@ -222,7 +227,12 @@ export async function collectPostRunIssues(
     const stale = await isSummaryUnchanged(summaryFilePath, summarySeed);
     if (stale) issues.summaryStale = { filePath: summaryFilePath };
   }
-  const unsubmittedMode = getUnsubmittedReview(ctx.toolState);
+  const expectsReviewOutput =
+    ctx.toolState.hadProgressComment ||
+    (ctx.payload.progressComments === false &&
+      ctx.payload.event.silent !== true &&
+      ctx.payload.event.issue_number !== undefined);
+  const unsubmittedMode = getUnsubmittedReview(ctx.toolState, expectsReviewOutput);
   if (unsubmittedMode) issues.unsubmittedReview = unsubmittedMode;
   return issues;
 }

--- a/main.ts
+++ b/main.ts
@@ -53,6 +53,7 @@ import {
 } from "./utils/packageManager.ts";
 import { aggregateUsage, patchWorkflowRunFields } from "./utils/patchWorkflowRunFields.ts";
 import { resolveOutputSchema, resolvePayload, resolvePromptInput } from "./utils/payload.ts";
+import { deleteProgressCommentApi } from "./utils/progressComment.ts";
 import { runProxyResolution } from "./utils/proxy.ts";
 import { fetchPreviousSnapshot, persistSummary, seedSummaryFile } from "./utils/prSummary.ts";
 import { handleAgentResult } from "./utils/run.ts";
@@ -200,6 +201,9 @@ export async function main(): Promise<MainResult> {
   toolState.model = payload.model;
   toolState.oss = runContext.oss;
   toolState.shaPinned = isActionPinnedToSha();
+  if (payload.event.issue_number) {
+    primaryRepoState(toolState).issueNumber = payload.event.issue_number;
+  }
   if (payload.event.trigger === "pull_request_synchronize") {
     primaryRepoState(toolState).beforeSha = payload.event.before_sha;
   }
@@ -261,6 +265,24 @@ export async function main(): Promise<MainResult> {
   // create octokit with MCP token for GitHub API calls.
   // the refresh handles mid-run token invalidation (#891)
   const octokit = createOctokit(tokenRef.mcpToken, getMcpTokenRefresh());
+
+  if (!payload.progressComments) {
+    const comment = toolState.progressComment;
+    if (comment) {
+      try {
+        await deleteProgressCommentApi(
+          { octokit, owner: runContext.repo.owner, repo: runContext.repo.name },
+          comment
+        );
+        toolState.progressComment = undefined;
+        log.info("» progress comments disabled; removed initial comment");
+      } catch (error) {
+        // Keep the handle so a final review can retry the deletion. Live writes
+        // remain disabled by the payload gate below.
+        log.warning(`» failed to remove initial progress comment: ${error}`);
+      }
+    }
+  }
 
   const runInfo = await resolveRun({ octokit });
   let toolContext: ToolContext | undefined;

--- a/mcp/comment.test.ts
+++ b/mcp/comment.test.ts
@@ -1,0 +1,76 @@
+import type { ToolState } from "../toolState.ts";
+import type { TodoTracker } from "../utils/todoTracking.ts";
+import { deleteProgressComment, reportProgress, ReportProgressTool } from "./comment.ts";
+import type { ToolContext } from "./server.ts";
+
+describe("reportProgress", () => {
+  it("skips live progress comments when they are disabled", async () => {
+    const toolState = {} as ToolState;
+    const ctx = {
+      payload: { progressComments: false, event: {} },
+      toolState,
+    } as ToolContext;
+
+    await expect(
+      reportProgress(ctx, { body: "Reviewing the diff", liveProgress: true })
+    ).resolves.toEqual({
+      body: "Reviewing the diff",
+      action: "skipped",
+    });
+    expect(toolState.lastProgressBody).toBeUndefined();
+  });
+
+  it("still publishes final result comments with task details", async () => {
+    const todoTracker = {
+      cancel: vi.fn(),
+      settled: vi.fn().mockResolvedValue(undefined),
+      renderCollapsible: vi.fn().mockReturnValue("<details>Task list</details>"),
+    } as unknown as TodoTracker;
+    const toolState = { todoTracker } as ToolState;
+    const createComment = vi.fn().mockResolvedValue({
+      data: { id: 123, body: "Review complete", html_url: "https://example.com/comment/123" },
+    });
+    const ctx = {
+      payload: { progressComments: false, event: { issue_number: 42 } },
+      repo: { owner: "pullfrog", name: "pullfrog" },
+      octokit: { rest: { issues: { createComment } } },
+      toolState,
+    } as unknown as ToolContext;
+    const tool = ReportProgressTool(ctx);
+
+    await (tool.execute as (params: unknown, context: unknown) => Promise<unknown>)(
+      { body: "Review complete" },
+      {} as Parameters<NonNullable<typeof tool.execute>>[1]
+    );
+
+    expect(createComment).toHaveBeenCalledOnce();
+    expect(createComment.mock.calls[0][0].body).toContain("<details>Task list</details>");
+    expect(todoTracker.cancel).toHaveBeenCalledOnce();
+    expect(toolState.finalSummaryWritten).toBe(true);
+  });
+
+  it("leaves reporting open when no comment exists to delete", async () => {
+    const toolState = {} as ToolState;
+    const ctx = { toolState } as ToolContext;
+
+    await expect(deleteProgressComment(ctx)).resolves.toBe(false);
+    expect(toolState.progressComment).toBeUndefined();
+  });
+
+  it("treats an already-deleted progress comment as successfully removed", async () => {
+    const toolState = {
+      progressComment: { id: 123, type: "issue" },
+    } as ToolState;
+    const deleteComment = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("Not Found"), { status: 404 }));
+    const ctx = {
+      repo: { owner: "pullfrog", name: "pullfrog" },
+      octokit: { rest: { issues: { deleteComment } } },
+      toolState,
+    } as unknown as ToolContext;
+
+    await expect(deleteProgressComment(ctx)).resolves.toBe(true);
+    expect(toolState.progressComment).toBeNull();
+  });
+});

--- a/mcp/comment.ts
+++ b/mcp/comment.ts
@@ -8,6 +8,7 @@ import { patchWorkflowRunFields } from "../utils/patchWorkflowRunFields.ts";
 import {
   createLeapingProgressComment,
   deleteProgressCommentApi,
+  isNotFoundError,
   updateProgressComment,
 } from "../utils/progressComment.ts";
 import type { ToolContext } from "./server.ts";
@@ -18,10 +19,6 @@ export {
   isLeapingIntoActionCommentBody,
   LEAPING_INTO_ACTION_PREFIX,
 } from "../utils/leapingComment.ts";
-
-function isNotFoundError(error: unknown): boolean {
-  return error instanceof Error && error.message.includes("Not Found");
-}
 
 function buildCommentFooter(ctx: ToolContext, customParts?: string[]): string {
   const runId = ctx.runId;
@@ -202,6 +199,10 @@ export async function reportProgress(
   // or skip salvage entirely) and triggers stranded-comment deletion.
   if (!params.liveProgress) {
     ctx.toolState.lastProgressBody = body;
+  }
+
+  if (params.liveProgress && !ctx.payload.progressComments) {
+    return { body, action: "skipped" };
   }
 
   // silent events (e.g., auto-label, pr-summary Task) should never create or update progress comments.
@@ -429,19 +430,12 @@ export function ReportProgressTool(ctx: ToolContext) {
  */
 export async function deleteProgressComment(ctx: ToolContext): Promise<boolean> {
   const existing = ctx.toolState.progressComment;
-  if (!existing) {
-    return false;
-  }
+  if (!existing) return false;
 
-  try {
-    await deleteProgressCommentApi(
-      { octokit: ctx.octokit, owner: ctx.repo.owner, repo: ctx.repo.name },
-      existing
-    );
-  } catch (error) {
-    // ignore 404 - comment already deleted
-    if (!isNotFoundError(error)) throw error;
-  }
+  await deleteProgressCommentApi(
+    { octokit: ctx.octokit, owner: ctx.repo.owner, repo: ctx.repo.name },
+    existing
+  );
 
   // set to null (not undefined) so report_progress skips instead of creating a new comment
   ctx.toolState.progressComment = null;

--- a/mcp/review.test.ts
+++ b/mcp/review.test.ts
@@ -8,8 +8,34 @@ import {
   MAX_DROPPED_COMMENT_LINES,
   type ReviewCommentInput,
   reviewSkipDecision,
+  sealProgressAfterReview,
   validateInlineComments,
 } from "./review.ts";
+import type { ToolContext } from "./server.ts";
+
+describe("sealProgressAfterReview", () => {
+  it("seals comment-free disabled review runs", () => {
+    const ctx = {
+      payload: { progressComments: false },
+      toolState: { progressComment: undefined },
+    } as unknown as ToolContext;
+
+    sealProgressAfterReview(ctx);
+
+    expect(ctx.toolState.progressComment).toBeNull();
+  });
+
+  it("does not change enabled runs without a progress comment", () => {
+    const ctx = {
+      payload: { progressComments: true },
+      toolState: { progressComment: undefined },
+    } as unknown as ToolContext;
+
+    sealProgressAfterReview(ctx);
+
+    expect(ctx.toolState.progressComment).toBeUndefined();
+  });
+});
 
 describe("commentableLinesForFile", () => {
   it("returns empty sets for missing patches (binary or no changes)", () => {

--- a/mcp/review.ts
+++ b/mcp/review.ts
@@ -191,6 +191,13 @@ export async function countOutstandingPullfrogThreads(
   return count;
 }
 
+/** Prevent a post-review report from recreating progress chrome suppressed at startup. */
+export function sealProgressAfterReview(ctx: ToolContext): void {
+  if (ctx.payload.progressComments === false && ctx.toolState.progressComment === undefined) {
+    ctx.toolState.progressComment = null;
+  }
+}
+
 /**
  * proactive approve-when-clean for the Fix-all / Fix-👍s flow (`fix_review`
  * trigger). when such a run completes successfully and every Pullfrog-originated
@@ -272,6 +279,7 @@ export async function approveAfterFix(ctx: ToolContext): Promise<void> {
   await deleteProgressComment(ctx).catch((err) => {
     log.debug(`progress comment cleanup after fix auto-approval failed: ${err}`);
   });
+  sealProgressAfterReview(ctx);
 }
 
 export type ReviewCommentInput = NonNullable<
@@ -852,6 +860,7 @@ export function CreatePullRequestReviewTool(ctx: ToolContext) {
         await deleteProgressComment(ctx).catch((err) => {
           log.debug(`progress comment cleanup after review failed: ${err}`);
         });
+        sealProgressAfterReview(ctx);
 
         // detect commits pushed since checkout and guide the agent to review them
         // inline instead of dispatching a separate workflow run

--- a/utils/payload.test.ts
+++ b/utils/payload.test.ts
@@ -17,6 +17,9 @@ describe("Inputs schema", () => {
     ["shell", "restricted"],
     ["shell", "disabled"],
     ["shell", undefined],
+    ["progress_comments", "enabled"],
+    ["progress_comments", "disabled"],
+    ["progress_comments", undefined],
     ["timeout", "10m"],
     ["timeout", "1h30m"],
     ["timeout", "30s"],
@@ -26,10 +29,13 @@ describe("Inputs schema", () => {
     expect(() => Inputs.assert(input)).not.toThrow();
   });
 
-  it.each([["push"], ["shell"]] as const)("should reject invalid %s values", (prop) => {
-    const input = { prompt: "test", [prop]: "invalid" as any };
-    expect(() => Inputs.assert(input)).toThrow();
-  });
+  it.each([["push"], ["shell"], ["progress_comments"]] as const)(
+    "should reject invalid %s values",
+    (prop) => {
+      const input = { prompt: "test", [prop]: "invalid" as any };
+      expect(() => Inputs.assert(input)).toThrow();
+    }
+  );
 });
 
 describe("JsonPayload schema", () => {

--- a/utils/payload.ts
+++ b/utils/payload.ts
@@ -15,6 +15,7 @@ const PushPermissionInput = type.enumerated("disabled", "restricted", "enabled")
 // check-runs (branch protection). off by default — a new required-check
 // surface must not silently turn on.
 const StatusChecksInput = type.enumerated("disabled", "enabled");
+const ProgressCommentsInput = type.enumerated("disabled", "enabled");
 
 // schema for JSON payload passed via prompt (internal dispatch invocation)
 // note: permissions are intentionally NOT included here to prevent injection attacks
@@ -69,6 +70,7 @@ export const Inputs = type({
   "push?": PushPermissionInput.or("undefined"),
   "shell?": ShellPermissionInput.or("undefined"),
   "status_checks?": StatusChecksInput.or("undefined"),
+  "progress_comments?": ProgressCommentsInput.or("undefined"),
   "cwd?": type.string.or("undefined"),
   "output_schema?": type.string.or("undefined"),
 });
@@ -146,6 +148,7 @@ function resolveNonPromptInputs() {
     push: core.getInput("push") || undefined,
     shell: core.getInput("shell") || undefined,
     status_checks: core.getInput("status_checks") || undefined,
+    progress_comments: core.getInput("progress_comments") || undefined,
   });
 }
 
@@ -229,6 +232,13 @@ export function resolvePayload(
     // opt-in commit-status check-runs (branch protection). workflow-level
     // static input, off unless the repo's pullfrog.yml sets status_checks: enabled.
     statusChecks: inputs.status_checks === "enabled",
+
+    // action input overrides the repository setting; enabled by default for
+    // backward compatibility with existing workflows and run-context payloads.
+    progressComments:
+      inputs.progress_comments === undefined
+        ? repoSettings.progressComments
+        : inputs.progress_comments === "enabled",
 
     // set by proxy logic in main.ts when routing through OpenRouter
     proxyModel: undefined as string | undefined,

--- a/utils/progressComment.ts
+++ b/utils/progressComment.ts
@@ -98,6 +98,13 @@ interface ApiCtx {
   repo: string;
 }
 
+export function isNotFoundError(error: unknown): boolean {
+  return (
+    (typeof error === "object" && error !== null && "status" in error && error.status === 404) ||
+    (error instanceof Error && error.message.includes("Not Found"))
+  );
+}
+
 /**
  * Fetch a progress comment via the appropriate REST endpoint for its type.
  * Returns the common subset of fields callers actually use.
@@ -169,19 +176,25 @@ export async function deleteProgressCommentApi(
   ctx: ApiCtx,
   comment: ProgressComment
 ): Promise<void> {
-  if (comment.type === "review") {
-    await ctx.octokit.rest.pulls.deleteReviewComment({
+  try {
+    if (comment.type === "review") {
+      await ctx.octokit.rest.pulls.deleteReviewComment({
+        owner: ctx.owner,
+        repo: ctx.repo,
+        comment_id: comment.id,
+      });
+      return;
+    }
+    await ctx.octokit.rest.issues.deleteComment({
       owner: ctx.owner,
       repo: ctx.repo,
       comment_id: comment.id,
     });
-    return;
+  } catch (error) {
+    // Deletion is idempotent: an already-removed progress comment is the
+    // desired state, regardless of whether it disappeared locally or remotely.
+    if (!isNotFoundError(error)) throw error;
   }
-  await ctx.octokit.rest.issues.deleteComment({
-    owner: ctx.owner,
-    repo: ctx.repo,
-    comment_id: comment.id,
-  });
 }
 
 /**

--- a/utils/run.test.ts
+++ b/utils/run.test.ts
@@ -1,0 +1,46 @@
+import type { AgentResult } from "../agents/shared.ts";
+import type { ToolContext } from "../mcp/server.ts";
+import type { ToolState } from "../toolState.ts";
+import { handleAgentResult } from "./run.ts";
+
+const mocks = vi.hoisted(() => ({
+  reportProgress: vi.fn(),
+  reportErrorToComment: vi.fn(),
+}));
+
+vi.mock("../mcp/comment.ts", () => ({ reportProgress: mocks.reportProgress }));
+vi.mock("./errorReport.ts", () => ({ reportErrorToComment: mocks.reportErrorToComment }));
+
+function makeParams(result: AgentResult) {
+  const toolState = {
+    hadProgressComment: true,
+    progressComment: undefined,
+  } as ToolState;
+  const toolContext = { toolState } as ToolContext;
+  return { result, toolContext, silent: false };
+}
+
+describe("handleAgentResult", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.reportErrorToComment.mockResolvedValue(undefined);
+  });
+
+  it("creates a fallback comment when the agent returns no result", async () => {
+    await handleAgentResult(makeParams({ success: true, output: "" }));
+
+    expect(mocks.reportErrorToComment).toHaveBeenCalledWith(
+      expect.objectContaining({ createIfMissing: true })
+    );
+  });
+
+  it("creates a fallback comment when result delivery fails", async () => {
+    mocks.reportProgress.mockRejectedValue(new Error("write failed"));
+
+    await handleAgentResult(makeParams({ success: true, output: "Completed work" }));
+
+    expect(mocks.reportErrorToComment).toHaveBeenCalledWith(
+      expect.objectContaining({ createIfMissing: true })
+    );
+  });
+});

--- a/utils/run.ts
+++ b/utils/run.ts
@@ -78,14 +78,19 @@ export async function handleAgentResult(ctx: HandleAgentResultParams): Promise<M
         // the write itself is failing (auth/permissions) — surface THAT, not
         // the generic "no progress" message, so the real cause isn't masked.
         const error = `failed to deliver agent result: ${getErrorMessage(writeError)}`;
-        await reportErrorToComment({ toolState, error, title: "Error" }).catch(() => {});
+        await reportErrorToComment({
+          toolState,
+          error,
+          title: "Error",
+          createIfMissing: true,
+        }).catch(() => {});
         return { success: false, error, output: ctx.result.output || "" };
       }
     }
 
     const error = ctx.result.error || "agent completed without reporting progress";
     try {
-      await reportErrorToComment({ toolState, error, title: "Error" });
+      await reportErrorToComment({ toolState, error, title: "Error", createIfMissing: true });
     } catch {}
     return { success: false, error, output: ctx.result.output || "" };
   }

--- a/utils/runContext.ts
+++ b/utils/runContext.ts
@@ -40,6 +40,7 @@ export interface RepoSettings {
   // as the final "may auto-merge" verdict. see autoMergeAfterApprove.
   autoMergeEnabled: boolean;
   signedCommits: boolean;
+  progressComments: boolean;
   modeInstructions: Record<string, string>;
   learnings: string | null;
   learningsHeadings: LearningsHeading[];
@@ -80,6 +81,7 @@ const defaultSettings: RepoSettings = {
   prApproveEnabled: false,
   autoMergeEnabled: false,
   signedCommits: false,
+  progressComments: true,
   modeInstructions: {},
   learnings: null,
   learningsHeadings: [],


### PR DESCRIPTION
Closes #64

## Summary

- Add a backward-compatible `progress_comments` action input and repository setting.
- Remove the initial progress comment and suppress live todo updates when disabled.
- Preserve final reviews, final result comments, collapsible task details, and failure reports.
- Keep review-completion safeguards correct for silent, incremental, and plain-prompt runs.

## Testing

- `pnpm typecheck`
- `pnpm build`
- `node scripts/check-entrypoint-imports.ts`
- `pnpm exec vitest run --exclude test/ci.test.ts` — 608 tests passed

`test/ci.test.ts` expects the parent monorepo workflow fixture and is not runnable from this standalone clone; upstream CI provides the expected layout.

## Integration notes

- `deleteProgressCommentApi`, exported through `internal/index.ts`, now treats a 404 as successful idempotent deletion instead of throwing. Server-side consumers that branch on 404 should be checked.
- As a follow-up, the dispatcher can skip creating the initial comment when the repository setting disables progress comments. Action-side deletion remains necessary for workflow-input overrides and rolling compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub comment behavior and post-run review hard-fail logic for PR workflows; defaults stay enabled, but misconfigured comment-free review runs could still fail or behave differently around review submission gates.
> 
> **Overview**
> Adds **`progress_comments`** (`enabled` / `disabled`) as a GitHub Action input and repository setting (default **enabled** for backward compatibility). When disabled, startup removes any seeded “Leaping into action…” comment, **`report_progress`** skips **live** todo/checklist updates, and **`sealProgressAfterReview`** blocks later steps from recreating that progress UI after a review.
> 
> **Final user-visible output is unchanged:** PR reviews, deliberate **`report_progress`** summaries (including collapsible task details), and error reporting still post to GitHub. **`handleAgentResult`** now passes **`createIfMissing: true`** so delivery failures can open a fresh issue comment when there is no progress comment handle (common in comment-free runs).
> 
> Post-run **unsubmitted review** enforcement no longer depends only on **`hadProgressComment`**. Comment-free runs with an **`issue_number`** still require **`create_pull_request_review`** (or **`report_progress`** for IncrementalReview), except **silent** events and runs with no issue target. **`main`** copies **`issue_number`** into primary repo state for that path.
> 
> **`deleteProgressCommentApi`** treats **404** as successful idempotent deletion (shared **`isNotFoundError`**). README documents standalone **`progress_comments: disabled`** usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5dc75a4ef1ffdc8b5d80a40749e1bd9a68cfdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->