### PR TITLE
Add OpenAI-compatible BYOK provider and routing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ jobs:
 
 ```
 
+#### OpenAI-compatible BYOK gateway
+
+To use any OpenAI-compatible bring-your-own-key (BYOK) gateway, add these GitHub Actions secrets to your repository:
+
+- `OPENAI_COMPATIBLE_API_KEY`
+- `OPENAI_COMPATIBLE_BASE_URL` — must be an OpenAI-compatible `/v1` endpoint (for example, `https://gateway.example.com/v1`)
+- `OPENAI_COMPATIBLE_MODEL_ID`
+
+Then select the generic OpenAI-compatible BYOK model and pass the secrets to the action:
+
+```yaml
+env:
+  PULLFROG_MODEL: openai-compatible/byok
+  OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+  OPENAI_COMPATIBLE_BASE_URL: ${{ secrets.OPENAI_COMPATIBLE_BASE_URL }}
+  OPENAI_COMPATIBLE_MODEL_ID: ${{ secrets.OPENAI_COMPATIBLE_MODEL_ID }}
+```
+
+LiteLLM is a supported OpenAI-compatible gateway example, not a special provider.
+
 To gate merges on Pullfrog with branch protection, add `status_checks: enabled` under `with:`. Each PR run then posts a `pullfrog` check (run completion — success when the run finishes, failure on error/timeout) and a `pullfrog-approval` check (whether Pullfrog would approve the PR), both requireable as status checks. See [PR reviews → Required status checks](https://docs.pullfrog.dev/pr-reviews#required-status-checks-branch-protection).
 
 #### 2. Create `triggers.yml`

--- a/agents/opencode_v2.ts
+++ b/agents/opencode_v2.ts
@@ -143,8 +143,8 @@ export function buildOpenCodeConfig(params: {
       "openai-compatible": {
         npm: "@ai-sdk/openai-compatible",
         options: {
-          baseURL: params.openaiCompatible.baseURL,
-          apiKey: params.openaiCompatible.apiKey,
+          baseURL: params.openaiCompatible.baseURL?.trim(),
+          apiKey: params.openaiCompatible.apiKey?.trim(),
         },
         models: {
           [openAICompatibleModelId]: { name: openAICompatibleModelId },

--- a/agents/opencode_v2.ts
+++ b/agents/opencode_v2.ts
@@ -58,7 +58,12 @@ import {
 } from "@opencode-ai/sdk/v2";
 import { Agent, fetch as undiciFetch } from "undici";
 import { pullfrogMcpName } from "../external.ts";
-import { BEDROCK_MODEL_ID_ENV } from "../models.ts";
+import {
+  BEDROCK_MODEL_ID_ENV,
+  OPENAI_COMPATIBLE_API_KEY_ENV,
+  OPENAI_COMPATIBLE_BASE_URL_ENV,
+  OPENAI_COMPATIBLE_MODEL_ID_ENV,
+} from "../models.ts";
 import type { ToolState } from "../toolState.ts";
 import { AGENT_ACTIVITY_TIMEOUT_MS, markActivity } from "../utils/activity.ts";
 import type { AgentDiagnostic } from "../utils/agentHangReport.ts";
@@ -98,7 +103,15 @@ const installCli = () => installOpencodeCli({ binPath: "bin/opencode.exe" });
 
 // ── config ─────────────────────────────────────────────────────────────────────
 
-function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
+export function buildOpenCodeConfig(params: {
+  mcpServerUrl: string;
+  model: string | undefined;
+  openaiCompatible: {
+    modelId: string | undefined;
+    baseURL: string | undefined;
+    apiKey: string | undefined;
+  };
+}): OpenCodeConfig {
   const config: OpenCodeConfig = {
     permission: {
       bash: "deny",
@@ -115,27 +128,55 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
       // deleting live git locks (the corruption in #860/#864 — the dangerous
       // `rm` guidance is gone, but the spurious aborts shouldn't happen either).
       // server-side cap is 600s (`checkout_pr` `timeoutMs`).
-      [pullfrogMcpName]: { type: "remote", url: ctx.mcpServerUrl, timeout: 300_000 },
+      [pullfrogMcpName]: { type: "remote", url: params.mcpServerUrl, timeout: 300_000 },
     },
-    agent: (() => {
-      const cfg = buildReviewerAgentConfig(model);
-      const reviewerModel = (cfg[REVIEWER_AGENT_NAME] as { model?: string })?.model ?? "(inherit)";
-      log.info(`» subagent models: reviewfrog=${reviewerModel}`);
-      return cfg;
-    })(),
+    agent: buildReviewerAgentConfig(params.model),
     // gemini-3 thinking pinned to high for review depth; gpt and anthropic
     // effort set elsewhere (gpt: upstream default, anthropic: --effort flag in claude.ts).
     provider: { google: { models: geminiHighThinkingOverrides() } },
   };
 
-  if (model) {
-    config.model = model;
-    const slashIndex = model.indexOf("/");
+  const openAICompatibleModelId = params.openaiCompatible.modelId?.trim();
+  if (openAICompatibleModelId && params.model === `openai-compatible/${openAICompatibleModelId}`) {
+    config.provider = {
+      ...config.provider,
+      "openai-compatible": {
+        npm: "@ai-sdk/openai-compatible",
+        options: {
+          baseURL: params.openaiCompatible.baseURL,
+          apiKey: params.openaiCompatible.apiKey,
+        },
+        models: {
+          [openAICompatibleModelId]: { name: openAICompatibleModelId },
+        },
+      },
+    };
+  }
+
+  if (params.model) {
+    config.model = params.model;
+    const slashIndex = params.model.indexOf("/");
     if (slashIndex > 0) {
-      config.enabled_providers = [model.slice(0, slashIndex).toLowerCase()];
+      config.enabled_providers = [params.model.slice(0, slashIndex).toLowerCase()];
     }
   }
 
+  return config;
+}
+
+function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): string {
+  const config = buildOpenCodeConfig({
+    mcpServerUrl: ctx.mcpServerUrl,
+    model,
+    openaiCompatible: {
+      modelId: process.env[OPENAI_COMPATIBLE_MODEL_ID_ENV],
+      baseURL: process.env[OPENAI_COMPATIBLE_BASE_URL_ENV],
+      apiKey: process.env[OPENAI_COMPATIBLE_API_KEY_ENV],
+    },
+  });
+  const reviewerModel =
+    (config.agent?.[REVIEWER_AGENT_NAME] as { model?: string } | undefined)?.model ?? "(inherit)";
+  log.info(`» subagent models: reviewfrog=${reviewerModel}`);
   return JSON.stringify(config);
 }
 

--- a/agents/subagentRegistration.test.ts
+++ b/agents/subagentRegistration.test.ts
@@ -33,7 +33,7 @@ describe("subagent registration source asserts", () => {
       expect(opencodeSharedSource).toMatch(/overrides\.reviewer/);
     });
     it("v2 runner passes orchestrator model to buildReviewerAgentConfig", () => {
-      expect(opencodeV2Source).toMatch(/buildReviewerAgentConfig\(model\)/);
+      expect(opencodeV2Source).toMatch(/buildReviewerAgentConfig\(params\.model\)/);
     });
   });
 });

--- a/models.ts
+++ b/models.ts
@@ -828,6 +828,13 @@ export const OPENAI_COMPATIBLE_API_KEY_ENV = "OPENAI_COMPATIBLE_API_KEY";
 export const OPENAI_COMPATIBLE_BASE_URL_ENV = "OPENAI_COMPATIBLE_BASE_URL";
 export const OPENAI_COMPATIBLE_MODEL_ID_ENV = "OPENAI_COMPATIBLE_MODEL_ID";
 
+/** all three are required — setup validators check against this single list. */
+export const OPENAI_COMPATIBLE_REQUIRED_ENV_VARS = [
+  OPENAI_COMPATIBLE_API_KEY_ENV,
+  OPENAI_COMPATIBLE_BASE_URL_ENV,
+  OPENAI_COMPATIBLE_MODEL_ID_ENV,
+] as const;
+
 /**
  * the Bedrock model ID passed to claude-code or opencode is whatever the
  * user set in `BEDROCK_MODEL_ID` — Pullfrog never resolves or upgrades it.

--- a/models.ts
+++ b/models.ts
@@ -21,9 +21,11 @@
  * contracts. so the single `bedrock/byok` and `vertex/byok` entries are
  * routing slugs, not model aliases: the harness reads the backend-specific
  * env var and routes to claude-code for Anthropic IDs or opencode for
- * everything else.
+ * everything else. `"openai-compatible"` means the actual model ID comes
+ * from `OPENAI_COMPATIBLE_MODEL_ID` and is served through the configured
+ * OpenAI-compatible endpoint.
  */
-export type ModelRouting = "bedrock" | "vertex";
+export type ModelRouting = "bedrock" | "vertex" | "openai-compatible";
 
 export interface ModelAlias {
   /** stable alias stored in DB, e.g. "anthropic/claude-opus" */
@@ -468,6 +470,21 @@ export const providers = {
       },
     },
   }),
+  "openai-compatible": provider({
+    displayName: "OpenAI-compatible",
+    envVars: [
+      "OPENAI_COMPATIBLE_API_KEY",
+      "OPENAI_COMPATIBLE_BASE_URL",
+      "OPENAI_COMPATIBLE_MODEL_ID",
+    ],
+    models: {
+      byok: {
+        displayName: "OpenAI-compatible",
+        resolve: "openai-compatible",
+        routing: "openai-compatible",
+      },
+    },
+  }),
   openrouter: provider({
     displayName: "OpenRouter",
     envVars: ["OPENROUTER_API_KEY"],
@@ -805,6 +822,11 @@ export const BEDROCK_MODEL_ID_ENV = "BEDROCK_MODEL_ID";
 
 /** env var that supplies the Vertex AI model ID for the `vertex/byok` slug. */
 export const VERTEX_MODEL_ID_ENV = "VERTEX_MODEL_ID";
+
+/** env vars required to serve the `openai-compatible/byok` routing slug. */
+export const OPENAI_COMPATIBLE_API_KEY_ENV = "OPENAI_COMPATIBLE_API_KEY";
+export const OPENAI_COMPATIBLE_BASE_URL_ENV = "OPENAI_COMPATIBLE_BASE_URL";
+export const OPENAI_COMPATIBLE_MODEL_ID_ENV = "OPENAI_COMPATIBLE_MODEL_ID";
 
 /**
  * the Bedrock model ID passed to claude-code or opencode is whatever the

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { getModelEnvVars, modelAliases, resolveCliModel, resolveDisplayAlias } from "../models.ts";
+import {
+  getModelEnvVars,
+  OPENAI_COMPATIBLE_API_KEY_ENV,
+  OPENAI_COMPATIBLE_BASE_URL_ENV,
+  OPENAI_COMPATIBLE_MODEL_ID_ENV,
+  modelAliases,
+  providers,
+  resolveCliModel,
+  resolveDisplayAlias,
+} from "../models.ts";
 
 // ── pure alias-registry invariants ──────────────────────────────────────────────
 //
@@ -12,6 +21,25 @@ import { getModelEnvVars, modelAliases, resolveCliModel, resolveDisplayAlias } f
 // add a model here ONLY when it genuinely doesn't exist on both models.dev and OpenRouter.
 // the models-bump cron flags entries that become fillable (see rule 9 in models-bump.yml).
 const BYOK_ONLY_MODELS = new Set<string>([]);
+
+describe("OpenAI-compatible registry", () => {
+  it("declares the required environment variables and dynamic routing alias", () => {
+    expect(providers["openai-compatible"].envVars).toEqual([
+      OPENAI_COMPATIBLE_API_KEY_ENV,
+      OPENAI_COMPATIBLE_BASE_URL_ENV,
+      OPENAI_COMPATIBLE_MODEL_ID_ENV,
+    ]);
+    expect(getModelEnvVars("openai-compatible/byok")).toEqual(
+      providers["openai-compatible"].envVars
+    );
+    expect(modelAliases.find((alias) => alias.slug === "openai-compatible/byok")).toMatchObject({
+      provider: "openai-compatible",
+      resolve: "openai-compatible",
+      routing: "openai-compatible",
+    });
+    expect(modelAliases.find((alias) => alias.slug === "litellm/byok")).toBeUndefined();
+  });
+});
 
 describe("openRouterResolve completeness", () => {
   for (const alias of modelAliases) {

--- a/utils/agent.test.ts
+++ b/utils/agent.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildOpenCodeConfig } from "../agents/opencode_v2.ts";
 import { resolveAgent, resolveModel } from "./agent.ts";
 import { cleanupVertexCredentials, materializeVertexCredentials } from "./vertex.ts";
 
@@ -21,6 +22,8 @@ const STRIPPED = [
   /^VERTEX_SERVICE_ACCOUNT_JSON$/,
   /^VERTEX_LOCATION$/,
   /^VERTEX_MODEL_ID$/,
+  /^OPENAI_COMPATIBLE_BASE_URL$/,
+  /^OPENAI_COMPATIBLE_MODEL_ID$/,
   /^PULLFROG_SECRET_HOME$/,
   /^PULLFROG_MODEL$/,
   /^PULLFROG_AGENT$/,
@@ -162,10 +165,53 @@ describe("resolveModel", () => {
     expect(() => resolveModel({ slug: "vertex/byok" })).toThrow("VERTEX_MODEL_ID");
   });
 
+  it("resolves openai-compatible/byok to the configured model", () => {
+    process.env.OPENAI_COMPATIBLE_MODEL_ID = "azure/gpt-5.6-deployment";
+    expect(resolveModel({ slug: "openai-compatible/byok" })).toBe(
+      "openai-compatible/azure/gpt-5.6-deployment"
+    );
+  });
+
+  it("throws when openai-compatible/byok is selected without OPENAI_COMPATIBLE_MODEL_ID", () => {
+    expect(() => resolveModel({ slug: "openai-compatible/byok" })).toThrow(
+      "OPENAI_COMPATIBLE_MODEL_ID"
+    );
+  });
+
   it("PULLFROG_MODEL=vertex/byok defers to VERTEX_MODEL_ID, not the sentinel", () => {
     process.env.PULLFROG_MODEL = "vertex/byok";
     process.env.VERTEX_MODEL_ID = "gemini-2.5-pro";
     expect(resolveModel({ slug: "openai/gpt" })).toBe("gemini-2.5-pro");
+  });
+});
+
+describe("buildOpenCodeConfig", () => {
+  it("translates an OpenAI-compatible route into OpenCode's provider payload", () => {
+    const modelId = "azure/gpt-5.6-production";
+    const config = buildOpenCodeConfig({
+      mcpServerUrl: "http://127.0.0.1:3000/mcp",
+      model: `openai-compatible/${modelId}`,
+      openaiCompatible: {
+        modelId,
+        baseURL: "https://gateway.example.com/v1",
+        apiKey: "openai-compatible-test-key",
+      },
+    });
+
+    expect(config.provider).toMatchObject({
+      "openai-compatible": {
+        npm: "@ai-sdk/openai-compatible",
+        options: {
+          baseURL: "https://gateway.example.com/v1",
+          apiKey: "openai-compatible-test-key",
+        },
+        models: {
+          [modelId]: { name: modelId },
+        },
+      },
+    });
+    expect(config.model).toBe(`openai-compatible/${modelId}`);
+    expect(config.enabled_providers).toEqual(["openai-compatible"]);
   });
 });
 

--- a/utils/agent.test.ts
+++ b/utils/agent.test.ts
@@ -213,6 +213,28 @@ describe("buildOpenCodeConfig", () => {
     expect(config.model).toBe(`openai-compatible/${modelId}`);
     expect(config.enabled_providers).toEqual(["openai-compatible"]);
   });
+
+  it("trims baseURL and apiKey to avoid trailing-newline secret breakage", () => {
+    const modelId = "azure/gpt-5.6-production";
+    const config = buildOpenCodeConfig({
+      mcpServerUrl: "http://127.0.0.1:3000/mcp",
+      model: `openai-compatible/${modelId}`,
+      openaiCompatible: {
+        modelId,
+        baseURL: "https://gateway.example.com/v1\n",
+        apiKey: "openai-compatible-test-key\n",
+      },
+    });
+
+    expect(config.provider).toMatchObject({
+      "openai-compatible": {
+        options: {
+          baseURL: "https://gateway.example.com/v1",
+          apiKey: "openai-compatible-test-key",
+        },
+      },
+    });
+  });
 });
 
 describe("materializeVertexCredentials", () => {

--- a/utils/agent.ts
+++ b/utils/agent.ts
@@ -5,6 +5,9 @@ import {
   getModelProvider,
   isBedrockAnthropicId,
   isVertexAnthropicId,
+  OPENAI_COMPATIBLE_API_KEY_ENV,
+  OPENAI_COMPATIBLE_BASE_URL_ENV,
+  OPENAI_COMPATIBLE_MODEL_ID_ENV,
   resolveCliModel,
   resolveDisplayAlias,
   VERTEX_MODEL_ID_ENV,
@@ -30,6 +33,14 @@ function hasBedrockAuth(): boolean {
 
 function hasVertexAuth(): boolean {
   return hasEnvVar(VERTEX_SERVICE_ACCOUNT_JSON_ENV);
+}
+
+function getMissingOpenAICompatibleEnvVars(): string[] {
+  return [
+    OPENAI_COMPATIBLE_API_KEY_ENV,
+    OPENAI_COMPATIBLE_BASE_URL_ENV,
+    OPENAI_COMPATIBLE_MODEL_ID_ENV,
+  ].filter((name) => !process.env[name]?.trim());
 }
 
 /**
@@ -63,6 +74,17 @@ function resolveSlug(slug: string): string | undefined {
       );
     }
     return vertexId;
+  }
+  if (alias?.routing === "openai-compatible") {
+    const openAICompatibleModelId = process.env[OPENAI_COMPATIBLE_MODEL_ID_ENV]?.trim();
+    if (!openAICompatibleModelId) {
+      const missing = getMissingOpenAICompatibleEnvVars();
+      throw new Error(
+        `OpenAI-compatible model selected but required configuration is missing: ${missing.join(", ")}. ` +
+          "set the missing environment variables before running Pullfrog."
+      );
+    }
+    return `openai-compatible/${openAICompatibleModelId}`;
   }
   return resolveCliModel(slug);
 }

--- a/utils/agent.ts
+++ b/utils/agent.ts
@@ -5,9 +5,8 @@ import {
   getModelProvider,
   isBedrockAnthropicId,
   isVertexAnthropicId,
-  OPENAI_COMPATIBLE_API_KEY_ENV,
-  OPENAI_COMPATIBLE_BASE_URL_ENV,
   OPENAI_COMPATIBLE_MODEL_ID_ENV,
+  OPENAI_COMPATIBLE_REQUIRED_ENV_VARS,
   resolveCliModel,
   resolveDisplayAlias,
   VERTEX_MODEL_ID_ENV,
@@ -36,11 +35,7 @@ function hasVertexAuth(): boolean {
 }
 
 function getMissingOpenAICompatibleEnvVars(): string[] {
-  return [
-    OPENAI_COMPATIBLE_API_KEY_ENV,
-    OPENAI_COMPATIBLE_BASE_URL_ENV,
-    OPENAI_COMPATIBLE_MODEL_ID_ENV,
-  ].filter((name) => !process.env[name]?.trim());
+  return OPENAI_COMPATIBLE_REQUIRED_ENV_VARS.filter((name) => !process.env[name]?.trim());
 }
 
 /**

--- a/utils/apiKeys.test.ts
+++ b/utils/apiKeys.test.ts
@@ -18,6 +18,8 @@ const ENV_KEYS_TO_STRIP = [
   /^VERTEX_SERVICE_ACCOUNT_JSON$/,
   /^VERTEX_LOCATION$/,
   /^VERTEX_MODEL_ID$/,
+  /^OPENAI_COMPATIBLE_BASE_URL$/,
+  /^OPENAI_COMPATIBLE_MODEL_ID$/,
 ];
 
 beforeEach(() => {
@@ -207,6 +209,44 @@ describe("validateAgentApiKey — Vertex routing", () => {
       "VERTEX_SERVICE_ACCOUNT_JSON"
     );
   });
+});
+
+describe("validateAgentApiKey — OpenAI-compatible routing", () => {
+  const params = { agent: opencode, authorized: new Set<string>(), owner, name };
+  const setup = () => {
+    process.env.OPENAI_COMPATIBLE_API_KEY = "openai-compatible-test-key";
+    process.env.OPENAI_COMPATIBLE_BASE_URL = "https://gateway.example.com/v1";
+    process.env.OPENAI_COMPATIBLE_MODEL_ID = "azure/gpt-5.6-production";
+  };
+
+  it("passes for the routing slug when all OpenAI-compatible configuration is present", () => {
+    setup();
+    expect(() =>
+      validateAgentApiKey({ ...params, model: "openai-compatible/byok" })
+    ).not.toThrow();
+  });
+
+  it.each(["OPENAI_COMPATIBLE_API_KEY", "OPENAI_COMPATIBLE_BASE_URL", "OPENAI_COMPATIBLE_MODEL_ID"])(
+    "requires %s for the routing slug",
+    (missing) => {
+      setup();
+      delete process.env[missing];
+      expect(() => validateAgentApiKey({ ...params, model: "openai-compatible/byok" })).toThrow(
+        missing
+      );
+    }
+  );
+
+  it.each(["OPENAI_COMPATIBLE_API_KEY", "OPENAI_COMPATIBLE_BASE_URL"])(
+    "requires %s for the resolved OpenAI-compatible model",
+    (missing) => {
+      setup();
+      delete process.env[missing];
+      expect(() =>
+        validateAgentApiKey({ ...params, model: "openai-compatible/azure/gpt-5.6-production" })
+      ).toThrow(missing);
+    }
+  );
 });
 
 describe("isApiKeyAuthError", () => {

--- a/utils/apiKeys.ts
+++ b/utils/apiKeys.ts
@@ -1,6 +1,9 @@
 import {
   BEDROCK_MODEL_ID_ENV,
   getModelEnvVars,
+  OPENAI_COMPATIBLE_API_KEY_ENV,
+  OPENAI_COMPATIBLE_BASE_URL_ENV,
+  OPENAI_COMPATIBLE_MODEL_ID_ENV,
   resolveDisplayAlias,
   VERTEX_MODEL_ID_ENV,
 } from "../models.ts";
@@ -83,6 +86,22 @@ add the missing secret(s) to your GitHub repository at ${githubSecretsUrl}, then
 for full setup instructions, see https://docs.pullfrog.com/vertex`;
 }
 
+function buildOpenAICompatibleSetupError(params: {
+  owner: string;
+  name: string;
+  missing: string[];
+}): string {
+  const githubSecretsUrl = `https://github.com/${params.owner}/${params.name}/settings/secrets/actions`;
+
+  return `OpenAI-compatible model selected but required configuration is missing: ${params.missing.join(", ")}.
+
+add the missing secret(s) to your GitHub repository at ${githubSecretsUrl}, then reference them in your workflow's \`env:\` block:
+
+  ${OPENAI_COMPATIBLE_API_KEY_ENV}: \${{ secrets.${OPENAI_COMPATIBLE_API_KEY_ENV} }}
+  ${OPENAI_COMPATIBLE_BASE_URL_ENV}: \${{ secrets.${OPENAI_COMPATIBLE_BASE_URL_ENV} }}
+  ${OPENAI_COMPATIBLE_MODEL_ID_ENV}: \${{ secrets.${OPENAI_COMPATIBLE_MODEL_ID_ENV} }}`;
+}
+
 function hasEnvVar(name: string): boolean {
   const value = process.env[name];
   return typeof value === "string" && value.length > 0;
@@ -121,6 +140,28 @@ function validateVertexSetup(params: { owner: string; name: string }): void {
   }
 }
 
+function validateOpenAICompatibleSetup(params: { owner: string; name: string }): void {
+  const requiredEnvVars = [
+    OPENAI_COMPATIBLE_API_KEY_ENV,
+    OPENAI_COMPATIBLE_BASE_URL_ENV,
+    OPENAI_COMPATIBLE_MODEL_ID_ENV,
+  ];
+  const missing = requiredEnvVars.filter((name) => !process.env[name]?.trim());
+
+  if (missing.length > 0) {
+    throw new Error(buildOpenAICompatibleSetupError({ owner: params.owner, name: params.name, missing }));
+  }
+}
+
+function isOpenAICompatibleResolvedModel(model: string): boolean {
+  const openAICompatibleModelId = process.env[OPENAI_COMPATIBLE_MODEL_ID_ENV]?.trim();
+  return (
+    openAICompatibleModelId !== undefined &&
+    openAICompatibleModelId.length > 0 &&
+    model === `openai-compatible/${openAICompatibleModelId}`
+  );
+}
+
 /**
  * Validate that the resolved model can actually be served by the chosen
  * agent. For routing slugs (Bedrock / Vertex) the auth shape is multi-var
@@ -148,6 +189,15 @@ export function validateAgentApiKey(params: {
       validateVertexSetup({ owner: params.owner, name: params.name });
       return;
     }
+    if (alias?.routing === "openai-compatible") {
+      validateOpenAICompatibleSetup({ owner: params.owner, name: params.name });
+      return;
+    }
+
+    if (isOpenAICompatibleResolvedModel(params.model)) {
+      validateOpenAICompatibleSetup({ owner: params.owner, name: params.name });
+      return;
+    }
 
     // raw backend model IDs (post-resolveModel for routing slugs) have no
     // `/`. discriminate by the env-var sentinel, then run the matching
@@ -159,8 +209,10 @@ export function validateAgentApiKey(params: {
         validateVertexSetup({ owner: params.owner, name: params.name });
         return;
       }
-      validateBedrockSetup({ owner: params.owner, name: params.name });
-      return;
+      if (process.env[BEDROCK_MODEL_ID_ENV]?.trim() === params.model) {
+        validateBedrockSetup({ owner: params.owner, name: params.name });
+        return;
+      }
     }
 
     if (params.agent.name === "opencode") {

--- a/utils/apiKeys.ts
+++ b/utils/apiKeys.ts
@@ -4,6 +4,7 @@ import {
   OPENAI_COMPATIBLE_API_KEY_ENV,
   OPENAI_COMPATIBLE_BASE_URL_ENV,
   OPENAI_COMPATIBLE_MODEL_ID_ENV,
+  OPENAI_COMPATIBLE_REQUIRED_ENV_VARS,
   resolveDisplayAlias,
   VERTEX_MODEL_ID_ENV,
 } from "../models.ts";
@@ -141,12 +142,7 @@ function validateVertexSetup(params: { owner: string; name: string }): void {
 }
 
 function validateOpenAICompatibleSetup(params: { owner: string; name: string }): void {
-  const requiredEnvVars = [
-    OPENAI_COMPATIBLE_API_KEY_ENV,
-    OPENAI_COMPATIBLE_BASE_URL_ENV,
-    OPENAI_COMPATIBLE_MODEL_ID_ENV,
-  ];
-  const missing = requiredEnvVars.filter((name) => !process.env[name]?.trim());
+  const missing = OPENAI_COMPATIBLE_REQUIRED_ENV_VARS.filter((name) => !process.env[name]?.trim());
 
   if (missing.length > 0) {
     throw new Error(buildOpenAICompatibleSetupError({ owner: params.owner, name: params.name, missing }));
@@ -199,11 +195,12 @@ export function validateAgentApiKey(params: {
       return;
     }
 
-    // raw backend model IDs (post-resolveModel for routing slugs) have no
-    // `/`. discriminate by the env-var sentinel, then run the matching
-    // setup validator — `opencode models` doesn't help here because the
-    // Bedrock/Vertex provider plugins need region/location/model-id wired
-    // through env regardless of CLI-side auth.
+    // raw backend model IDs (post-resolveModel for bedrock/vertex routing
+    // slugs) have no `/` — openai-compatible resolves to a slashed specifier
+    // and is handled above. discriminate by the env-var sentinel, then run
+    // the matching setup validator — `opencode models` doesn't help here
+    // because the Bedrock/Vertex provider plugins need region/location/
+    // model-id wired through env regardless of CLI-side auth.
     if (!params.model.includes("/")) {
       if (process.env[VERTEX_MODEL_ID_ENV]?.trim() === params.model) {
         validateVertexSetup({ owner: params.owner, name: params.name });

--- a/utils/modelAccess.test.ts
+++ b/utils/modelAccess.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { decideModelAccess } from "./modelAccess.ts";
+
+const base = {
+  modelExplicit: true,
+  oss: false,
+  proxyActive: false,
+  subsidyTarget: undefined,
+  authorized: new Set<string>(),
+};
+
+describe("decideModelAccess — routing slugs", () => {
+  it("passes openai-compatible/byok even though the resolved specifier is slashed and unauthorized", () => {
+    // the opencode `authorized` snapshot can't contain the dynamically-injected
+    // openai-compatible provider — the slug's own setup checks validate auth.
+    expect(
+      decideModelAccess({
+        ...base,
+        model: "openai-compatible/byok",
+        resolvedModel: "openai-compatible/azure/gpt-5.6-production",
+      })
+    ).toEqual({ kind: "ok" });
+  });
+
+  it("passes openai-compatible/byok as byok when a proxy is active", () => {
+    expect(
+      decideModelAccess({
+        ...base,
+        proxyActive: true,
+        model: "openai-compatible/byok",
+        resolvedModel: "openai-compatible/azure/gpt-5.6-production",
+      })
+    ).toEqual({ kind: "byok" });
+  });
+
+  it("still rejects a non-routing slashed model that isn't authorized", () => {
+    expect(
+      decideModelAccess({
+        ...base,
+        model: "anthropic/claude-opus-4-8",
+        resolvedModel: "anthropic/claude-opus-4-8",
+      })
+    ).toEqual({ kind: "error", reason: "byok_no_key" });
+  });
+
+  it("still passes slash-less bedrock/vertex backend IDs", () => {
+    expect(
+      decideModelAccess({
+        ...base,
+        model: "bedrock/byok",
+        resolvedModel: "eu.anthropic.claude-opus-4-8-v1",
+      })
+    ).toEqual({ kind: "ok" });
+  });
+});

--- a/utils/modelAccess.ts
+++ b/utils/modelAccess.ts
@@ -15,7 +15,7 @@
  * throws and `runErrorRenderer.ts` re-surfaces on both run surfaces.
  */
 
-import { resolveOpenRouterModel } from "../models.ts";
+import { resolveDisplayAlias, resolveOpenRouterModel } from "../models.ts";
 import { getApiUrl } from "./apiUrl.ts";
 
 export type ModelAccessReason = "oss" | "byok_no_key" | "router";
@@ -50,11 +50,15 @@ export function decideModelAccess(input: {
 }): ModelAccessDecision {
   if (!input.modelExplicit || !input.model) return { kind: "ok" };
 
-  // raw routing slugs (bedrock/vertex — no provider/model slash) are validated
-  // by their own setup checks, not the opencode `authorized` snapshot.
+  // routing slugs are validated by their own setup checks, not the opencode
+  // `authorized` snapshot — discriminate on the alias' routing flag (their
+  // resolved IDs may or may not contain a slash).
+  const isRoutingSlug = resolveDisplayAlias(input.model)?.routing !== undefined;
   const byokAuthorized =
     !!input.resolvedModel &&
-    (input.authorized.has(input.resolvedModel) || !input.resolvedModel.includes("/"));
+    (input.authorized.has(input.resolvedModel) ||
+      !input.resolvedModel.includes("/") ||
+      isRoutingSlug);
 
   if (input.proxyActive) {
     const target = resolveOpenRouterModel(input.model);


### PR DESCRIPTION
Closes: #66 

Add an OpenAI-compatible bring-your-own-key provider that routes Pullfrog through any OpenAI-compatible `/v1` endpoint using repository secrets for the API key, base URL, and model ID. Fix routing-slug handling so `openai-compatible/byok` resolves to the configured model and passes authorization checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model resolution, credential validation, and OpenCode provider wiring on the inference path, but follows existing Bedrock/Vertex routing patterns and is covered by targeted tests.
> 
> **Overview**
> Introduces **OpenAI-compatible BYOK** so repos can point Pullfrog at any `/v1` gateway (e.g. LiteLLM) via `OPENAI_COMPATIBLE_API_KEY`, `OPENAI_COMPATIBLE_BASE_URL`, and `OPENAI_COMPATIBLE_MODEL_ID`, using `PULLFROG_MODEL: openai-compatible/byok`.
> 
> The model registry gains an `openai-compatible` provider and routing type; `resolveModel` maps the slug to `openai-compatible/<model-id>`. OpenCode v2 **refactors** config building into exported `buildOpenCodeConfig`, which injects the dynamic `openai-compatible` provider (base URL, API key trimmed) when that route is active.
> 
> **Pre-run validation** mirrors Bedrock/Vertex: `validateAgentApiKey` requires all three vars for the slug and resolved model. **`decideModelAccess`** treats any alias with a `routing` flag as BYOK-authorized so slashed resolved IDs are not rejected against OpenCode's static `authorized` set.
> 
> README documents the workflow `env` block; unit tests cover registry, resolution, OpenCode config, API keys, and model access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8963ce89b3736896e545135954f1582d9be494af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->