### PR TITLE
feat(action): validate Azure setup instead of reporting a missing key

### DIFF
--- a/utils/apiKeys.test.ts
+++ b/utils/apiKeys.test.ts
@@ -18,6 +18,8 @@ const ENV_KEYS_TO_STRIP = [
   /^VERTEX_SERVICE_ACCOUNT_JSON$/,
   /^VERTEX_LOCATION$/,
   /^VERTEX_MODEL_ID$/,
+  /^AZURE_RESOURCE_NAME$/,
+  /^AZURE_COGNITIVE_SERVICES_RESOURCE_NAME$/,
 ];
 
 beforeEach(() => {
@@ -206,6 +208,65 @@ describe("validateAgentApiKey — Vertex routing", () => {
     expect(() => validateAgentApiKey({ ...params, model: "gemini-2.5-pro" })).toThrow(
       "VERTEX_SERVICE_ACCOUNT_JSON"
     );
+  });
+});
+
+describe("validateAgentApiKey — Azure", () => {
+  const params = { agent: opencode, owner, name };
+  const model = "azure/gpt-5.6-sol";
+
+  it("passes when the model is in the authorized set", () => {
+    process.env.AZURE_RESOURCE_NAME = "my-resource";
+    process.env.AZURE_API_KEY = "azure-key";
+    expect(() =>
+      validateAgentApiKey({ ...params, model, authorized: new Set([model]) })
+    ).not.toThrow();
+  });
+
+  it("names the missing resource name rather than claiming no key was found", () => {
+    process.env.AZURE_API_KEY = "azure-key";
+    expect(() => validateAgentApiKey({ ...params, model, authorized: new Set() })).toThrow(
+      "AZURE_RESOURCE_NAME"
+    );
+  });
+
+  it("names the missing api key", () => {
+    process.env.AZURE_RESOURCE_NAME = "my-resource";
+    expect(() => validateAgentApiKey({ ...params, model, authorized: new Set() })).toThrow(
+      "AZURE_API_KEY"
+    );
+  });
+
+  it("blames the deployment name when both vars are set but the model is unauthorized", () => {
+    // the case the generic copy gets wrong: credentials are fine, the Azure
+    // deployment is just named something other than the model id.
+    process.env.AZURE_RESOURCE_NAME = "my-resource";
+    process.env.AZURE_API_KEY = "azure-key";
+    let raised: Error | undefined;
+    try {
+      validateAgentApiKey({ ...params, model, authorized: new Set() });
+    } catch (error) {
+      raised = error as Error;
+    }
+    expect(raised?.message).toContain("deployment name mismatch");
+    expect(raised?.message).toContain("gpt-5.6-sol");
+    expect(raised?.message).not.toContain("no API key found");
+  });
+
+  it("uses the cognitive-services env var names for that provider", () => {
+    expect(() =>
+      validateAgentApiKey({
+        ...params,
+        model: "azure-cognitive-services/gpt-5.6-sol",
+        authorized: new Set(),
+      })
+    ).toThrow("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME");
+  });
+
+  it("leaves non-Azure providers on the generic missing-key error", () => {
+    expect(() =>
+      validateAgentApiKey({ ...params, model: "openai/gpt-5.6-sol", authorized: new Set() })
+    ).toThrow("no API key found");
   });
 });
 

--- a/utils/apiKeys.ts
+++ b/utils/apiKeys.ts
@@ -83,6 +83,47 @@ add the missing secret(s) to your GitHub repository at ${githubSecretsUrl}, then
 for full setup instructions, see https://docs.pullfrog.com/vertex`;
 }
 
+/** models.dev exposes two Azure providers, differing only in env-var prefix.
+ * `azure` fronts `<resource>.openai.azure.com`; `azure-cognitive-services`
+ * fronts an AI Services / Foundry resource. */
+const AZURE_PROVIDERS: Record<string, { resourceName: string; apiKey: string }> = {
+  azure: { resourceName: "AZURE_RESOURCE_NAME", apiKey: "AZURE_API_KEY" },
+  "azure-cognitive-services": {
+    resourceName: "AZURE_COGNITIVE_SERVICES_RESOURCE_NAME",
+    apiKey: "AZURE_COGNITIVE_SERVICES_API_KEY",
+  },
+};
+
+function buildAzureSetupError(params: {
+  owner: string;
+  name: string;
+  model: string;
+  deployment: string;
+  missing: string[];
+  envVars: { resourceName: string; apiKey: string };
+}): string {
+  const githubSecretsUrl = `https://github.com/${params.owner}/${params.name}/settings/secrets/actions`;
+
+  if (params.missing.length > 0) {
+    return `Azure model selected but required configuration is missing: ${params.missing.join(", ")}.
+
+add the missing secret(s) to your GitHub repository at ${githubSecretsUrl}, then reference them in your workflow's \`env:\` block:
+
+  ${params.envVars.resourceName}: my-resource
+  ${params.envVars.apiKey}: \${{ secrets.${params.envVars.apiKey} }}
+
+\`${params.envVars.resourceName}\` is the resource name alone, not a URL — for \`https://my-resource.openai.azure.com\` it is \`my-resource\`.`;
+  }
+
+  return `Azure is configured (${params.envVars.resourceName} + ${params.envVars.apiKey} are both set) but OpenCode can't serve \`${params.model}\`.
+
+the most likely cause is a deployment name mismatch. the Azure provider addresses a *deployment*, not a model, and uses the model id as the deployment name — so your deployment must be named exactly \`${params.deployment}\`.
+
+check Azure AI Foundry → Deployments and either rename the deployment to \`${params.deployment}\`, or select the model whose id matches the name you already have.
+
+if the name does match, confirm \`${params.envVars.resourceName}\` points at the resource hosting that deployment.`;
+}
+
 function hasEnvVar(name: string): boolean {
   const value = process.env[name];
   return typeof value === "string" && value.length > 0;
@@ -119,6 +160,44 @@ function validateVertexSetup(params: { owner: string; name: string }): void {
   if (missing.length > 0) {
     throw new Error(buildVertexSetupError({ owner: params.owner, name: params.name, missing }));
   }
+}
+
+/**
+ * Azure arrives as a raw models.dev specifier (`azure/<model-id>`) rather than
+ * a curated slug, so there's no `routing` discriminant to branch on — the
+ * provider prefix is the only signal. Like Bedrock/Vertex the auth shape is
+ * multi-var, and unlike them there's a second failure mode that looks
+ * identical from `opencode models`: the provider addresses a *deployment* and
+ * uses the model id as the deployment name, so a differently-named deployment
+ * is indistinguishable from a missing key unless we say so explicitly.
+ *
+ * Only called once the caller has established the model is unauthorized, so
+ * this always throws for an Azure provider. Non-Azure providers return so the
+ * generic missing-key error still applies.
+ */
+function validateAzureSetup(params: {
+  owner: string;
+  name: string;
+  model: string;
+  provider: string;
+}): void {
+  const envVars = AZURE_PROVIDERS[params.provider];
+  if (!envVars) return;
+
+  const missing: string[] = [];
+  if (!hasEnvVar(envVars.apiKey)) missing.push(envVars.apiKey);
+  if (!hasEnvVar(envVars.resourceName)) missing.push(envVars.resourceName);
+
+  throw new Error(
+    buildAzureSetupError({
+      owner: params.owner,
+      name: params.name,
+      model: params.model,
+      deployment: params.model.slice(params.model.indexOf("/") + 1),
+      missing,
+      envVars,
+    })
+  );
 }
 
 /**
@@ -165,6 +244,16 @@ export function validateAgentApiKey(params: {
 
     if (params.agent.name === "opencode") {
       if (params.authorized.has(params.model)) return;
+      // azure carries no curated alias, so it never reaches the `routing`
+      // branches above. its config gaps and its deployment-name mismatch both
+      // surface here as "unauthorized", which the generic copy misdiagnoses as
+      // a missing key. no-ops for every other provider.
+      validateAzureSetup({
+        owner: params.owner,
+        name: params.name,
+        model: params.model,
+        provider: params.model.slice(0, params.model.indexOf("/")).toLowerCase(),
+      });
       throw new Error(
         buildMissingApiKeyError({ owner: params.owner, name: params.name, model: params.model })
       );


### PR DESCRIPTION
feel free to toss or reimplement. I got azure wired up successfully, but this is what came out of a review about improving pullfrog after doing so. I will note that azure foundry is pretty awkward, so it's easy to get this wrong... So better error messaging may help someone.

----

## Context

Azure-hosted OpenAI models already work today with no changes to Pullfrog: `resolveModel` passes a slashed non-curated value through as a raw models.dev specifier, the BYOK gate is `opencode models` output rather than a fixed allowlist, and models.dev ships an `azure` provider (`AZURE_RESOURCE_NAME` + `AZURE_API_KEY`) carrying the GPT models. We're running our PR reviews on `azure/gpt-5.6-sol` this way.

This PR doesn't add Azure support. It makes the failure mode legible when the setup is wrong.

## Problem

Because Azure has no curated alias, it carries no `routing` discriminant, so it skips the Bedrock and Vertex branches in `validateAgentApiKey` and lands on the generic `buildMissingApiKeyError`. That message is wrong for both ways Azure fails:

1. **A missing env var.** Set `AZURE_API_KEY` but not `AZURE_RESOURCE_NAME` and you're told no API key was found, pointing at the key you just added.
2. **A deployment name mismatch.** `@ai-sdk/azure` addresses a *deployment*, not a model, and uses the model id as the deployment name. Name your deployment `sol-review` instead of `gpt-5.6-sol` and it never enters the authorized set, so credentials that are completely fine report as a missing key.

The second one cost us the most time, and nothing in the output points at it.

## Change

`validateAzureSetup`, sited beside the two existing validators and following their shape. It names whichever var is absent; when both are present it explains the deployment-name coupling and says exactly what the deployment must be called.

Rendered, for `azure/gpt-5.6-sol` with both vars set:

```
Azure is configured (AZURE_RESOURCE_NAME + AZURE_API_KEY are both set) but
OpenCode can't serve `azure/gpt-5.6-sol`.

the most likely cause is a deployment name mismatch. the Azure provider
addresses a *deployment*, not a model, and uses the model id as the deployment
name — so your deployment must be named exactly `gpt-5.6-sol`.

check Azure AI Foundry → Deployments and either rename the deployment to
`gpt-5.6-sol`, or select the model whose id matches the name you already have.

if the name does match, confirm `AZURE_RESOURCE_NAME` points at the resource
hosting that deployment.
```

Both models.dev Azure providers are covered (`azure`, `azure-cognitive-services`), since they differ only in env-var prefix. The validator returns without throwing for any non-Azure provider, so the generic error path is untouched elsewhere — there's a test pinning that.

Deliberately no `docs.pullfrog.com/azure` link, since that page doesn't exist yet. Happy to write one as a follow-up if you'd take it.

## Tests

Six cases in `utils/apiKeys.test.ts`. Verified the four behavioral ones fail when the hook is disabled. `pnpm typecheck` clean, `utils/` 282/282. Didn't run the full suite (no GitHub App credentials locally).

Branched off `main`, independent of #69.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to pre-run validation error messaging in `utils/apiKeys.ts` with no auth or runtime behavior changes; non-Azure paths are explicitly no-ops.
> 
> **Overview**
> When an OpenCode run uses an unauthorized `azure/...` or `azure-cognitive-services/...` model, **`validateAgentApiKey` no longer falls through to the generic “no API key found” message.** It now runs **`validateAzureSetup`**, aligned with the existing Bedrock/Vertex setup validators.
> 
> Missing **`AZURE_RESOURCE_NAME`** / **`AZURE_API_KEY`** (or the cognitive-services equivalents) produce errors that name the specific env vars and how to set them in GitHub Actions. If both are set but the model still isn’t authorized, the error calls out a likely **deployment name mismatch** (Azure uses the model id as the deployment name) instead of blaming a missing key. Non-Azure providers still get the generic missing-key path.
> 
> Tests cover authorized success, missing vars, deployment mismatch copy, both Azure provider prefixes, and that other providers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21fa4cf01ac96f1ab8d8868cadb81d323839380c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->