### PR TITLE
feat(action): allow an explicit Azure endpoint via AZURE_BASE_URL

### DIFF
--- a/agents/opencode.test.ts
+++ b/agents/opencode.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { modelAliases } from "../models.ts";
 import { geminiHighThinkingOverrides } from "./opencode.ts";
+import { azureBaseUrlOverrides } from "./opencodeShared.ts";
 
 describe("geminiHighThinkingOverrides", () => {
   // Expected truth pulled the same way the helper does — both must derive from
@@ -30,5 +31,57 @@ describe("geminiHighThinkingOverrides", () => {
         options: { thinkingConfig: { thinkingLevel: "high" } },
       });
     }
+  });
+});
+
+describe("azureBaseUrlOverrides", () => {
+  const saved = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.AZURE_BASE_URL;
+    delete process.env.AZURE_COGNITIVE_SERVICES_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it("contributes nothing when neither var is set", () => {
+    // spread into `provider`, so an empty object has to be the unset default
+    expect(azureBaseUrlOverrides()).toEqual({});
+  });
+
+  it("maps AZURE_BASE_URL onto the azure provider", () => {
+    process.env.AZURE_BASE_URL = "https://my-resource.openai.azure.com/openai";
+    expect(azureBaseUrlOverrides()).toEqual({
+      azure: { options: { baseURL: "https://my-resource.openai.azure.com/openai" } },
+    });
+  });
+
+  it("maps the cognitive-services var onto its own provider id", () => {
+    process.env.AZURE_COGNITIVE_SERVICES_BASE_URL = "https://foo.cognitiveservices.azure.com/openai";
+    expect(azureBaseUrlOverrides()).toEqual({
+      "azure-cognitive-services": {
+        options: { baseURL: "https://foo.cognitiveservices.azure.com/openai" },
+      },
+    });
+  });
+
+  it("carries both providers independently", () => {
+    process.env.AZURE_BASE_URL = "https://a.openai.azure.com/openai";
+    process.env.AZURE_COGNITIVE_SERVICES_BASE_URL = "https://b.cognitiveservices.azure.com/openai";
+    expect(Object.keys(azureBaseUrlOverrides()).sort()).toEqual(["azure", "azure-cognitive-services"]);
+  });
+
+  it("trims surrounding whitespace", () => {
+    process.env.AZURE_BASE_URL = "  https://my-resource.openai.azure.com/openai\n";
+    expect(azureBaseUrlOverrides().azure?.options.baseURL).toBe(
+      "https://my-resource.openai.azure.com/openai"
+    );
+  });
+
+  it("treats a whitespace-only value as unset", () => {
+    process.env.AZURE_BASE_URL = "   ";
+    expect(azureBaseUrlOverrides()).toEqual({});
   });
 });

--- a/agents/opencode.ts
+++ b/agents/opencode.ts
@@ -45,6 +45,7 @@ import {
 } from "./opencodePlugin.ts";
 import {
   autoSelectModel,
+  azureBaseUrlOverrides,
   buildReviewerAgentConfig,
   deepseekHighEffortOverrides,
   geminiHighThinkingOverrides,
@@ -140,6 +141,8 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
       openrouter: {
         models: { ...deepseekHighEffortOverrides(), ...kimiOpenRouterProviderOverrides() },
       },
+      // no-op unless AZURE_BASE_URL / AZURE_COGNITIVE_SERVICES_BASE_URL is set
+      ...azureBaseUrlOverrides(),
     },
   };
 

--- a/agents/opencodeShared.ts
+++ b/agents/opencodeShared.ts
@@ -99,6 +99,46 @@ export function deepseekHighEffortOverrides(): Record<
   return orModel ? { [orModel]: { options: { reasoning: { effort: "high" } } } } : {};
 }
 
+/** env var carrying an explicit endpoint override, per models.dev Azure provider. */
+const AZURE_BASE_URL_ENV: Record<string, string> = {
+  azure: "AZURE_BASE_URL",
+  "azure-cognitive-services": "AZURE_COGNITIVE_SERVICES_BASE_URL",
+};
+
+/**
+ * Build the `provider.<azure-provider>.options.baseURL` entries that point the
+ * Azure providers at an explicit endpoint.
+ *
+ * Without this, `@ai-sdk/azure` derives its URL from a resource name as
+ * `https://<AZURE_RESOURCE_NAME>.openai.azure.com/openai`, which can't express
+ * an AI Foundry / AI Services host, an API Management front door, or an AI
+ * gateway. Supplying `baseURL` makes `resourceName` unnecessary — the SDK
+ * ignores it once a base URL is set.
+ *
+ * Wiring: config `provider.<id>.options` is merged over OpenCode's own provider
+ * options (`mergeDeep` in opencode `provider/provider.ts`), and `getSDK` reads
+ * `options.baseURL` (via `loadBaseURL`) straight into the `createAzure` factory.
+ * The provider still has to be *enabled*, which OpenCode does when any of the
+ * provider's models.dev env vars is present — `AZURE_API_KEY` alone is enough,
+ * so a custom endpoint doesn't need a dummy resource name.
+ *
+ * The value should carry the `/openai` suffix, matching both the SDK's own
+ * resource-name default and OpenCode's `azure-cognitive-services` loader:
+ *   https://my-resource.openai.azure.com/openai
+ *
+ * Returns `{}` when unset, so spreading it into `provider` is a no-op.
+ */
+export function azureBaseUrlOverrides(): Record<string, { options: { baseURL: string } }> {
+  const overrides: Record<string, { options: { baseURL: string } }> = {};
+  for (const [providerID, envVar] of Object.entries(AZURE_BASE_URL_ENV)) {
+    const baseURL = process.env[envVar]?.trim();
+    if (!baseURL) continue;
+    overrides[providerID] = { options: { baseURL } };
+    log.info(`» ${providerID} endpoint overridden via ${envVar}: ${baseURL}`);
+  }
+  return overrides;
+}
+
 /**
  * Read-only `reviewfrog` subagent for lens-based review. Non-mutative +
  * non-recursive — enforced by the system prompt in reviewer.ts.

--- a/agents/opencode_v2.ts
+++ b/agents/opencode_v2.ts
@@ -77,6 +77,7 @@ import {
 } from "./opencodePlugin.ts";
 import {
   autoSelectModel,
+  azureBaseUrlOverrides,
   buildReviewerAgentConfig,
   deepseekHighEffortOverrides,
   geminiHighThinkingOverrides,
@@ -136,6 +137,8 @@ function buildSecurityConfig(ctx: AgentRunContext, model: string | undefined): s
       openrouter: {
         models: { ...deepseekHighEffortOverrides(), ...kimiOpenRouterProviderOverrides() },
       },
+      // no-op unless AZURE_BASE_URL / AZURE_COGNITIVE_SERVICES_BASE_URL is set
+      ...azureBaseUrlOverrides(),
     },
   };
 


### PR DESCRIPTION
## Problem

Azure models work today through the models.dev passthrough, but only for one endpoint shape. `@ai-sdk/azure` derives its URL from a resource name:

```
https://<AZURE_RESOURCE_NAME>.openai.azure.com/openai
```

That can't express an Azure AI Foundry / AI Services host, an API Management front door, or an AI gateway. Those deployments are simply unreachable — there's no config surface to point the provider anywhere else.

## Change

`AZURE_BASE_URL` (plus `AZURE_COGNITIVE_SERVICES_BASE_URL` for the sibling provider), surfaced as `provider.<id>.options.baseURL` in the generated OpenCode config.

It lives in `opencodeShared.ts` and is spread into both the v1 and v2 `buildSecurityConfig` provider blocks, per that module's stated purpose of keeping the two runners from drifting. It returns `{}` when unset, so the emitted config is byte-identical for anyone not using it.

## Verification

I traced this through OpenCode rather than assuming the schema key was wired:

- `getSDK` spreads `provider.options`, calls `loadBaseURL` (`options["baseURL"] ?? model.api.url`), and passes the result to `BUNDLED_PROVIDERS["@ai-sdk/azure"] === createAzure`
- config `provider.<id>.options` is merged over OpenCode's own via `mergeDeep`
- per the ai-sdk source, `resourceName` is ignored and no longer required once `baseURL` is set

Then confirmed end to end against a local probe server, with `AZURE_API_KEY` set and `provider.azure.options.baseURL` pointed at it:

```
HIT POST /openai/v1/responses?api-version=v1
```

So the override reaches the SDK, and the Responses API is used (matching the `azure` custom loader's `sdk.responses()`). The base URL should carry the `/openai` suffix — the SDK appends `/v1{path}`.

One nice consequence, also verified empirically: OpenCode enables a provider when *any* of its models.dev env vars is present (`provider.env.map(...).find(Boolean)`). `AZURE_API_KEY` alone lists 66 `azure/*` models, zero with no azure var set. So a custom endpoint needs no dummy `AZURE_RESOURCE_NAME` to pass the authorization gate.

## Tests

Six cases in `agents/opencode.test.ts` covering both providers, trimming, whitespace-only, and the empty-by-default contract. `pnpm typecheck` clean; `utils/` + `agents/` 347/347. Full suite not run locally (no GitHub App credentials).

## Notes

Branched off `main`, independent of #69 and #70. If #69 lands, `AZURE_BASE_URL` and `AZURE_RESOURCE_NAME` are both worth adding to its non-secret allowlist so they stay readable in run logs — happy to do that in whichever merges second.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change gated on optional env vars; default emitted config is unchanged when vars are absent.
> 
> **Overview**
> Adds optional **Azure endpoint overrides** for OpenCode by mapping `AZURE_BASE_URL` and `AZURE_COGNITIVE_SERVICES_BASE_URL` into `provider.<id>.options.baseURL` in the generated security config, so deployments behind AI Foundry, API Management, or custom gateways are reachable without relying on resource-name URL derivation.
> 
> The helper **`azureBaseUrlOverrides()`** lives in `opencodeShared.ts` (trimmed values, empty when unset) and is spread into the `provider` block in both **v1 and v2** OpenCode harnesses so behavior stays aligned. When a var is set, an info log records which provider was overridden.
> 
> **Tests** cover both env vars, independent dual mapping, trimming, whitespace-only treated as unset, and the default `{}` no-op contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff33573666f64dd007cf52851f3e9112f87c866d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->