### PR TITLE
fix: remove the shared temp directory in the post hook

### DIFF
--- a/entryPost.ts
+++ b/entryPost.ts
@@ -28,7 +28,7 @@
 // Imports here MUST stay stdlib-only — GHA runs this file directly from the
 // checked-out action repo, which has no node_modules for sha-pinned consumers.
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { detectCodexRefresh } from "./utils/codexRefreshDetect.ts";
 import * as core from "./utils/ghaCore.ts";
 import { postApiFetch } from "./utils/postApiFetch.ts";
@@ -101,6 +101,41 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  core.warning(`codex post-hook: unexpected error — ${err}`);
-});
+/**
+ * Delete the shared temp directory created by `createTempDirectory()`.
+ *
+ * `mkdtempSync(join(tmpdir(), "pullfrog-"))` had no counterpart anywhere in
+ * the action, so every run left its checkout behind. On GitHub-hosted runners
+ * that is invisible — the VM is destroyed with the job — but a self-hosted
+ * runner accumulates one clone per run forever. It is worst when `/tmp` is a
+ * tmpfs: the leak is then RAM, not disk. One host reached 58 leaked clones
+ * (12 GB, `/tmp` 100% full) in a single day, which starved the box badly
+ * enough that the kernel OOM-killed unrelated jobs.
+ *
+ * Runs from `post:` rather than a `finally` in the main step so it also fires
+ * on cancellation, timeout, and unhandled errors — the paths that leak most.
+ * Best-effort by design: a failure here must never fail the job.
+ */
+function cleanupTempDir(): void {
+  const dir = core.getState("pullfrog_temp_dir");
+  // Only ever remove a directory we recognise as ours. The leaf is split by
+  // hand rather than with `basename` to keep entryPost's locked import
+  // surface (`node:fs` plus relative siblings) unchanged — see #834.
+  const leaf = dir.split(/[\\/]/).pop() ?? "";
+  if (!dir || !leaf.startsWith("pullfrog-")) return;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+    core.info(`pullfrog post-hook: removed temp dir ${dir}`);
+  } catch (err) {
+    core.warning(`pullfrog post-hook: temp dir cleanup failed — ${err}`);
+  }
+}
+
+// Cleanup runs after `main()` because the Codex write-back reads files that
+// may live inside the temp dir, and on both paths because the leak is the
+// whole point of the hook firing.
+main()
+  .catch((err) => {
+    core.warning(`codex post-hook: unexpected error — ${err}`);
+  })
+  .finally(cleanupTempDir);

--- a/entryPost.ts
+++ b/entryPost.ts
@@ -131,9 +131,8 @@ function cleanupTempDir(): void {
   }
 }
 
-// Cleanup runs after `main()` because the Codex write-back reads files that
-// may live inside the temp dir, and on both paths because the leak is the
-// whole point of the hook firing.
+// Cleanup runs last so nothing `main()` reads can be pulled out from under it,
+// and on both paths because the leak is the whole point of the hook firing.
 main()
   .catch((err) => {
     core.warning(`codex post-hook: unexpected error — ${err}`);

--- a/utils/setup.ts
+++ b/utils/setup.ts
@@ -2,6 +2,7 @@ import { execFileSync, execSync } from "node:child_process";
 import { mkdtempSync, readdirSync, realpathSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as core from "@actions/core";
 import type { ShellPermission } from "../external.ts";
 import { requireRepoState, type ToolState } from "../toolState.ts";
 import { log } from "./cli.ts";
@@ -19,6 +20,11 @@ export interface SetupOptions {
 export function createTempDirectory(): string {
   const sharedTempDir = mkdtempSync(join(tmpdir(), "pullfrog-"));
   process.env.PULLFROG_TEMP_DIR = sharedTempDir;
+  // Hand the path to the `post:` hook so it can delete the directory. The env
+  // var alone is not enough: `post:` runs in a separate node process, so it
+  // never sees a `process.env` mutation made here. `$GITHUB_STATE` survives
+  // that boundary and is explicitly preserved by `wipeRunnerLeakSurface()`.
+  core.saveState("pullfrog_temp_dir", sharedTempDir);
   log.info(`» created temp dir at ${sharedTempDir}`);
   return sharedTempDir;
 }


### PR DESCRIPTION
## Problem

`createTempDirectory()` (`utils/setup.ts:19`) does:

```ts
const sharedTempDir = mkdtempSync(join(tmpdir(), "pullfrog-"));
```

and nothing ever removes it. `entryPost.ts` (`post-if: always()`) — the natural place — contains no `rm`.

This looks like an oversight rather than a decision, because the same codebase disposes every *other* temp dir it creates:

| file | line |
|---|---|
| `utils/vertex.ts` | 73 |
| `utils/codexAuth.ts` | 111 |
| `mcp/xrepo.ts` | 151 |

The one that leaks is the big one — it holds the repo clone.

## Why it is easy to miss

On GitHub-hosted runners the whole VM is destroyed after the job, so the leak is invisible. It only affects **self-hosted** runners, where it accumulates one clone per run forever.

It is worst when `/tmp` is a tmpfs, because then the leak is RAM, not disk. On our host (`/tmp` = tmpfs at 50% of RAM) each run cost ~469 MB and we reached **58 leaked clones — 12 GB, `/tmp` 100% full** — in a single day on a 23.3 GB box:

```
tmpfs  12G  12G  0  100% /tmp
```

That left too little memory for the other workloads on the machine, and the kernel OOM-killed unrelated jobs four times.

## Change

- `utils/setup.ts` — `core.saveState("pullfrog_temp_dir", sharedTempDir)`. The existing `process.env.PULLFROG_TEMP_DIR` cannot reach the post hook: `post:` is a separate node process and never sees a `process.env` mutation from the main step. `$GITHUB_STATE` crosses that boundary and is already explicitly preserved by `wipeRunnerLeakSurface()`.
- `entryPost.ts` — `cleanupTempDir()` invoked via `.finally()`.

Design notes:

- Runs from `post:` rather than a `finally` in the main step, so it also fires on cancellation, timeout, and unhandled errors — the paths that leak most.
- Runs *after* `main()`, because the Codex write-back reads files that may live inside the temp dir.
- Guarded: only removes a directory whose leaf starts with `pullfrog-`.
- Best-effort — a failure is warned, never thrown. The workflow is already finished.
- The locked stdlib-only import surface from #834 is **unchanged**: the leaf is split by hand rather than importing `node:path`, so `entryPost.stdlibOnly.test.ts` still pins `["./utils/codexRefreshDetect.ts", "./utils/ghaCore.ts", "./utils/postApiFetch.ts", "node:fs"]`.

## Validation

- `pnpm typecheck` — clean (against upstream `main`, 0.1.65)
- `entryPost.stdlibOnly.test.ts` — 3/3 pass (all three invariants, including the locked import surface)
- `utils/setup.test.ts` — 4/4 pass
