### PR TITLE
feat(models): add gpt-astra alias for GPT-6 Astra

### DIFF
--- a/agents/codex.ts
+++ b/agents/codex.ts
@@ -549,6 +549,7 @@ const CODEX_MODEL_PRICING: Record<
   string,
   { input: number; cacheRead: number; cacheWrite: number; output: number }
 > = {
+  "gpt-6-astra": { input: 10, cacheRead: 1, cacheWrite: 12.5, output: 50 },
   "gpt-5.6-sol": { input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30 },
   "gpt-5.6-luna": { input: 0.2, cacheRead: 0.02, cacheWrite: 0.25, output: 1.2 },
   "gpt-5.6-terra": { input: 2, cacheRead: 0.2, cacheWrite: 2.5, output: 12 },

--- a/models.test.ts
+++ b/models.test.ts
@@ -82,6 +82,13 @@ describe("resolveModelSlug", () => {
     expect(resolved).toBe("openai/gpt-5.6-sol");
   });
 
+  it("resolves gpt-astra on every route that serves GPT-6", () => {
+    expect(resolveModelSlug("openai/gpt-astra")).toBe("openai/gpt-6-astra");
+    expect(resolveModelSlug("opencode/gpt-astra")).toBe("opencode/gpt-6-astra");
+    expect(resolveModelSlug("openrouter/gpt-astra")).toBe("openrouter/openai/gpt-6-astra");
+    expect(resolveModelSlug("vercel/gpt-astra")).toBe("vercel/openai/gpt-6-astra");
+  });
+
   it("returns the raw resolve for deprecated aliases (does not walk fallback)", () => {
     expect(resolveModelSlug("openai/gpt-codex")).toBe("openai/gpt-5.3-codex");
   });

--- a/models.ts
+++ b/models.ts
@@ -175,6 +175,16 @@ export const providers = {
     envVars: ["OPENAI_API_KEY"],
     managedCredentials: ["CODEX_AUTH_JSON"],
     models: {
+      // GPT-6's flagship tier (2026-09-04), priced 2.5x Sol. selectable but not
+      // preferred: Sol stays the auto-select target the way opus does beside
+      // fable — an explicit Astra pick spends Astra money. no `none` rung.
+      "gpt-astra": {
+        displayName: "GPT Astra",
+        resolve: "openai/gpt-6-astra",
+        effort: ["low", "medium", "high", "xhigh", "max"],
+        openRouterResolve: "openrouter/openai/gpt-6-astra",
+        subagentModel: "gpt-sol",
+      },
       // Sol/Terra/Luna are OpenAI's durable capability tiers, so they ARE the
       // brand-tier names the slug convention asks for — the pre-5.6 `gpt` /
       // `gpt-pro` / `gpt-mini` slugs are holdovers from the retired GPT / GPT Pro
@@ -532,6 +542,14 @@ export const providers = {
         displayName: "Claude Haiku",
         resolve: "opencode/claude-haiku-4-5",
         openRouterResolve: "openrouter/anthropic/claude-haiku-4.5",
+      },
+      // GPT-6 flagship — see openai above. on Zen's served list.
+      "gpt-astra": {
+        displayName: "GPT Astra",
+        resolve: "opencode/gpt-6-astra",
+        effort: ["low", "medium", "high", "xhigh", "max"],
+        openRouterResolve: "openrouter/openai/gpt-6-astra",
+        subagentModel: "gpt-sol",
       },
       "gpt-sol": {
         displayName: "GPT Sol",
@@ -948,6 +966,14 @@ export const providers = {
       // alias): after the Sol/Terra/Luna rename, ~gpt-mini-latest no longer maps
       // to Luna, so rolling aliases would silently diverge `gpt`/`gpt-mini` from
       // the chosen tiers across funding paths.
+      // GPT-6 flagship — see openai above.
+      "gpt-astra": {
+        displayName: "GPT Astra",
+        resolve: "openrouter/openai/gpt-6-astra",
+        effort: ["low", "medium", "high", "xhigh", "max"],
+        openRouterResolve: "openrouter/openai/gpt-6-astra",
+        subagentModel: "gpt-sol",
+      },
       "gpt-sol": {
         displayName: "GPT Sol",
         resolve: "openrouter/openai/gpt-5.6-sol",
@@ -1118,6 +1144,14 @@ export const providers = {
       "claude-haiku": {
         displayName: "Claude Haiku",
         resolve: "vercel/anthropic/claude-haiku-4.5",
+      },
+      // GPT-6 flagship — see openai above. the gateway publishes a `none` rung
+      // OpenAI's own catalog does not, so this ladder mirrors vercel's, not openai's.
+      "gpt-astra": {
+        displayName: "GPT Astra",
+        resolve: "vercel/openai/gpt-6-astra",
+        effort: ["none", "low", "medium", "high", "xhigh", "max"],
+        subagentModel: "gpt-sol",
       },
       "gpt-sol": {
         displayName: "GPT Sol",

--- a/models.ts
+++ b/models.ts
@@ -962,10 +962,6 @@ export const providers = {
         resolve: "openrouter/~anthropic/claude-haiku-latest",
         openRouterResolve: "openrouter/~anthropic/claude-haiku-latest",
       },
-      // pinned to the explicit gpt-5.6 tiers (not the ~openai/gpt-latest rolling
-      // alias): after the Sol/Terra/Luna rename, ~gpt-mini-latest no longer maps
-      // to Luna, so rolling aliases would silently diverge `gpt`/`gpt-mini` from
-      // the chosen tiers across funding paths.
       // GPT-6 flagship — see openai above.
       "gpt-astra": {
         displayName: "GPT Astra",
@@ -974,6 +970,10 @@ export const providers = {
         openRouterResolve: "openrouter/openai/gpt-6-astra",
         subagentModel: "gpt-sol",
       },
+      // pinned to the explicit gpt-5.6 tiers (not the ~openai/gpt-latest rolling
+      // alias): after the Sol/Terra/Luna rename, ~gpt-mini-latest no longer maps
+      // to Luna, so rolling aliases would silently diverge `gpt`/`gpt-mini` from
+      // the chosen tiers across funding paths.
       "gpt-sol": {
         displayName: "GPT Sol",
         resolve: "openrouter/openai/gpt-5.6-sol",

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -20,6 +20,7 @@ const BYOK_ONLY_MODELS = new Set<string>([
   "vercel/claude-opus",
   "vercel/claude-sonnet",
   "vercel/claude-haiku",
+  "vercel/gpt-astra",
   "vercel/gpt-sol",
   "vercel/gpt-terra",
   "vercel/gpt-luna",


### PR DESCRIPTION
Closes #88.

GPT-6 Astra shipped 2026-09-04. models.dev lists it on openai, opencode,
openrouter and vercel, and OpenCode Zen's served list now carries it (it
did not when #88 was triaged), so it gets a `gpt-astra` alias in all four
provider blocks. New slug rather than a `gpt-sol` bump: models.dev files
it under its own family, and a bump would silently 2.5x the cost for
everyone pinned to Sol.

- not `preferred` — Sol stays the auto-select target, the way opus stays
  preferred beside fable. promotion is a separate one-line decision.
- effort ladder mirrors models.dev per route: openai/opencode/openrouter
  publish no `none` rung for Astra; vercel's gateway does.
- `CODEX_MODEL_PRICING` gains an Astra row at today's models.dev list
  price (10/50) so a codex run on it reports a cost rather than null.
  note the existing Sol row (5/30) no longer matches models.dev (4/20).

Verified: typecheck clean, models.test.ts 183/183, test:catalog 430/434 —
the four failures reproduce on main (OpenRouter renamed qwen3.8-max to a
dated snapshot; Zen now serves glm-5.3) and are unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog and pricing-table additions with tests; no changes to auth, billing enforcement, or existing Sol pins.
> 
> **Overview**
> Adds a new **`gpt-astra`** model alias for OpenAI’s GPT-6 flagship tier (`gpt-6-astra`) across **openai**, **opencode**, **openrouter**, and **vercel**, so users can pick it explicitly without bumping **`gpt-sol`** (which would change cost for everyone pinned to Sol).
> 
> **Sol stays the auto-select default** — Astra is selectable but not `preferred`. Effort rungs follow each route’s catalog (no `none` on direct OpenAI/OpenCode/OpenRouter; **vercel** includes `none`). Subagent fanout for Astra uses **`gpt-sol`**.
> 
> **Codex runs** get modeled USD via a new **`gpt-6-astra`** row in `CODEX_MODEL_PRICING`. **`vercel/gpt-astra`** is listed in **`BYOK_ONLY_MODELS`** like other gateway-only entries. Tests cover multi-route slug resolution for `gpt-astra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b6405888ca64eb25a1378df58bec35bd424c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->